### PR TITLE
Fixed broken procedures

### DIFF
--- a/src/fabric-1.16.2/templates/modbase/mod.java.ftl
+++ b/src/fabric-1.16.2/templates/modbase/mod.java.ftl
@@ -92,29 +92,10 @@ public class ${JavaModName} implements ModInitializer {
 <#--				${block}_BLOCK.genBlock(biome);-->
 <#--			</#list>-->
 <#--		});-->
-		WorldTickCallback.EVENT.register((world) -> {
+
 		<#list w.getElementsOfType("PROCEDURE") as procedure>
-			new ${procedure}Procedure().worldTick(world);
+			new ${procedure}Procedure();
 		</#list>
-		});
-		UseBlockCallback.EVENT.register((player, world, hand, hitResult) -> {
-		<#list w.getElementsOfType("PROCEDURE") as procedure>
-			new ${procedure}Procedure().useOnBlock(player, world, hand, hitResult);
-		</#list>
-			return ActionResult.PASS;
-		});
-		UseEntityCallback.EVENT.register((player, world, hand, entity, hitResult) -> {
-		<#list w.getElementsOfType("PROCEDURE") as procedure>
-			new ${procedure}Procedure().useOnEntity(player, world, hand, entity, hitResult);
-		</#list>
-			return ActionResult.PASS;
-		});
-		UseItemCallback.EVENT.register((player, world, hand) -> {
-		<#list w.getElementsOfType("PROCEDURE") as procedure>
-			new ${procedure}Procedure().useItem(player, world, hand);
-		</#list>
-			return TypedActionResult.pass(player.getStackInHand(hand));
-		});
 
 		<#list w.getElementsOfType("CODE") as code>
 			${code}CustomCode.initialize();

--- a/src/fabric-1.16.2/triggers/player_right_click_block.java.ftl
+++ b/src/fabric-1.16.2/triggers/player_right_click_block.java.ftl
@@ -1,5 +1,5 @@
-@Override
-public void useOnBlock(PlayerEntity player, World world, Hand hand, BlockHitResult hitResult){
+public ${name}Procedure() {
+	UseBlockCallback.EVENT.register((player, world, hand, hitResult) -> {
 		Map<String, Object> dependencies = new HashMap<>();
 		int i=(int) player.getX();
 		int j=(int) player.getY();
@@ -10,4 +10,6 @@ public void useOnBlock(PlayerEntity player, World world, Hand hand, BlockHitResu
 		dependencies.put("y" ,j);
 		dependencies.put("z" ,k);
 		executeProcedure(dependencies);
+		return ActionResult.PASS;
+	});
 }

--- a/src/fabric-1.16.2/triggers/player_right_click_entity.java.ftl
+++ b/src/fabric-1.16.2/triggers/player_right_click_entity.java.ftl
@@ -1,5 +1,5 @@
-@Override
-public void useOnEntity(PlayerEntity player, World world, Hand hand, Entity entity, /* Nullable */ EntityHitResult hitResult){
+public ${name}Procedure() {
+	UseEntityCallback.EVENT.register((player, world, hand, entity, hitResult) -> {
 		Map<String, Object> dependencies = new HashMap<>();
 		int i=(int) player.getX();
 		int j=(int) player.getY();
@@ -11,4 +11,6 @@ public void useOnEntity(PlayerEntity player, World world, Hand hand, Entity enti
 		dependencies.put("y" ,j);
 		dependencies.put("z" ,k);
 		executeProcedure(dependencies);
+		return ActionResult.PASS;
+	});
 }

--- a/src/fabric-1.16.2/triggers/player_right_click_item.java.ftl
+++ b/src/fabric-1.16.2/triggers/player_right_click_item.java.ftl
@@ -1,5 +1,5 @@
-@Override
-public void useItem(PlayerEntity player, World world, Hand hand) {
+public ${name}Procedure() {
+	UseItemCallback.EVENT.register((player, world, hand) -> {
 		Map<String, Object> dependencies = new HashMap<>();
 		int i=(int) player.getX();
 		int j=(int) player.getY();
@@ -10,4 +10,6 @@ public void useItem(PlayerEntity player, World world, Hand hand) {
 		dependencies.put("y" ,j);
 		dependencies.put("z" ,k);
 		executeProcedure(dependencies);
+		return TypedActionResult.pass(player.getStackInHand(hand));
+	});
 }

--- a/src/fabric-1.16.2/triggers/world_ticks.java.ftl
+++ b/src/fabric-1.16.2/triggers/world_ticks.java.ftl
@@ -1,6 +1,7 @@
-@Override
-public void worldTick(World world){
-    Map<String, Object> dependencies = new HashMap<>();
-    dependencies.put("world",world);
-    executeProcedure(dependencies);
+public ${name}Procedure() {
+	WorldTickCallback.EVENT.register((world) -> {
+		Map<String, Object> dependencies = new HashMap<>();
+		dependencies.put("world",world);
+		executeProcedure(dependencies);
+	});
 }


### PR DESCRIPTION
**Version:-** 1.0.0 Alpha 2
### Changes

> This is caused because of the way global triggers are registered. I suggest registering this in a bit different way. I can provide an idea of this if interested (a pull request)?
> 
> Basically I would move EVENT.register calls to optional constructor of the procedure and add this only when global trigger is selected and then construct a procedure object from the main mod file.

### Bug Fixes
* Closes #45
