### PR TITLE
Add GUI mod element and support for inventories

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Unsupported fields in full supported mod elements are features from Forge only. 
 * Fuel
 * Function
 * Game rule
+* GUI
 * Item group
   Missing: Re-order creative tabs
 * Key binding
@@ -48,7 +49,6 @@ Unsupported fields in full supported mod elements are features from Forge only. 
 
 ### Not supported
 * Fluid
-* GUI
 
 ## Installation Instructions
 Pre-built binaries can be found on the [Release page of this repository](https://github.com/Goldorion/Fabric-Generator-MCreator/releases).

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 ## 1.5
 * Added full support for custom GUIs
 * Added support for Block entity (Block's inventory)
+* Added support for item inventory
 * Added support for following GUI related procedure blocks: Get text in textfield, Is checkbox checked, Set text in textfield
 * [Bugfix] Using the custom drop option in custom blocks caused a build error (due to a changed from the last version)
 * [Bugfix] On block right-clicked block trigger caused a build error

--- a/changelog.md
+++ b/changelog.md
@@ -1,15 +1,19 @@
 # Changelogs:
+
 ## 1.5
+
 * Added full support for custom GUIs
 * Added support for Block entity (Block's inventory)
 * Added support for item inventory
 * Added support for entity inventory
-* Added support for following GUI related procedure blocks: Get text in textfield, Is checkbox checked, Set text in textfield
+* Added support for following GUI related procedure blocks: Deal damage to item in slot, Get amount in slot, get item in
+  slot, remove items, Set item in slot, Get text in textfield, Is checkbox checked, Set text in textfield
 * [Bugfix] Using the custom drop option in custom blocks caused a build error (due to a changed from the last version)
 * [Bugfix] On block right-clicked block trigger caused a build error
 * [Bugfix] Right-click in air item trigger caused a build error.
 
 ## 1.4.2
+
 * [Bugfix] Custom biome sounds caused a build error
 * [Bugfix] BerryBushes, SwampClayDisk and TaigaLargeFerns default features caused a build due to a wrong value
 * [Bugfix] On initial spawn entity trigger caused a build error when a procedure was selected
@@ -18,6 +22,7 @@
 * [Bugfix #146, #147, #148] Mod elements having an element selected inside a block/item selector always failed to build.
 
 ## 1.4.1
+
 * [Bugfix] Right-click in air tool trigger caused a build error.
 * [Bugfix] Custom shears caused a build error
 * [Bugfix] Special and multi-tool weren't fully supported (causing build errors)
@@ -25,28 +30,49 @@
 * [Bugfix #142] Enabling the `Does emit redstone` property for custom blocks caused a build error
 
 ## 1.4
+
 ### Release
-* Added the possibility to generate custom biomes in the Nether and The End.
-  // Read the tooltip of the biome dictionnary.
+
+* Added the possibility to generate custom biomes in the Nether and The End. // Read the tooltip of the biome
+  dictionnary.
 * Added support for the Action Result Type procedure block
-* Added support for new logic related procedure blocks: Advancement is equal to, compare dimension id, compare entities, compare itemstacks, compare items
-* Added support for new blocks related procedure blocks: Block is fertilizable, is valid position, is waterloggable, NBT logic get, NBT logic set, get hardness, is solid, get light level, get opacity, convert block to item, Provided blockstate, Item to block
+* Added support for new logic related procedure blocks: Advancement is equal to, compare dimension id, compare entities,
+  compare itemstacks, compare items
+* Added support for new blocks related procedure blocks: Block is fertilizable, is valid position, is waterloggable, NBT
+  logic get, NBT logic set, get hardness, is solid, get light level, get opacity, convert block to item, Provided
+  blockstate, Item to block
 * Added support for new fluid related procedure blocks: Is fluid, is fluid source, get fluid at
-* Added support for new direction related procedure blocks: Compare axes, x offset, y, offset, z offset, rotate clockwise, rotate counterclockwise
-* Added support for new entity and player related procedure blocks: Add exhaustion, add potion, add potion (advanced), add recipe, check creature type, deal custom damage, get dimension ID, get absorption, get armor slot item, get flying speed, get oxygen, get saturation, get scoreboard score, get walk speed, get owner, get riding entity, get target entity, has no gravity, has recipe, is elytra flying, is tagged in, is alive, is blocking, is child, is immune to explosions, is immune to fire, is in lava, is in water, is in water or bubble column, is invisible, is invulnerable, is leashed, is non boss, is on ground, is tamed, is tamed by, make ride, make tamed, move entity
-* Added support for new item and itemstack related procedure blocks: Can smelt, check rarity, deal damage [#89], enchanted with xp, fuel power, get food value, get max damage [#89], get saturation value, is food, is tool, is name, name, NBT logic/number/String get/set, set damage [#89], set display name, show totem like animation, item entity to itemstack, get count, grow, itemstack iterator, remove specific enchantment, shrink
-* Added support for new world related procedure blocks: Place structure, play sound, provided dimension id, run function, get dimension id, get height at, get number of players in provided world, for each player in the world
+* Added support for new direction related procedure blocks: Compare axes, x offset, y, offset, z offset, rotate
+  clockwise, rotate counterclockwise
+* Added support for new entity and player related procedure blocks: Add exhaustion, add potion, add potion (advanced),
+  add recipe, check creature type, deal custom damage, get dimension ID, get absorption, get armor slot item, get flying
+  speed, get oxygen, get saturation, get scoreboard score, get walk speed, get owner, get riding entity, get target
+  entity, has no gravity, has recipe, is elytra flying, is tagged in, is alive, is blocking, is child, is immune to
+  explosions, is immune to fire, is in lava, is in water, is in water or bubble column, is invisible, is invulnerable,
+  is leashed, is non boss, is on ground, is tamed, is tamed by, make ride, make tamed, move entity
+* Added support for new item and itemstack related procedure blocks: Can smelt, check rarity, deal damage [#89],
+  enchanted with xp, fuel power, get food value, get max damage [#89], get saturation value, is food, is tool, is name,
+  name, NBT logic/number/String get/set, set damage [#89], set display name, show totem like animation, item entity to
+  itemstack, get count, grow, itemstack iterator, remove specific enchantment, shrink
+* Added support for new world related procedure blocks: Place structure, play sound, provided dimension id, run
+  function, get dimension id, get height at, get number of players in provided world, for each player in the world
+
 ### Snapshot 1
+
 Note: Incompatible with MCreator 2021.2.31709 and older
+
 * Update to MCreator 2021.2
 * Improved generated code style in some places
-* Disabled all unsupported parameters for armor, biome, block, enchantment, food, item, living entity, music disc, plant, potion effect, ranged item and tool mod elements
+* Disabled all unsupported parameters for armor, biome, block, enchantment, food, item, living entity, music disc,
+  plant, potion effect, ranged item and tool mod elements
 * Added support for custom potion and custom potion effect (the split)
 * Added missing features for custom potion effects
 * Added support for new block bases: End rod, Pressure plate and Button
 * Added support for the fishing rod tool type
-* Added support for new block parameters: Custom sound set, Redstone properties, placing condition, on right-clicked and on block placed by triggers
-* Added support for new plant parameters: Double plant, Custom sound set, Creative pick item, Placing condition, Custom set of blocks a plant can be placed/grow on, On block added and On block placed by triggers
+* Added support for new block parameters: Custom sound set, Redstone properties, placing condition, on right-clicked and
+  on block placed by triggers
+* Added support for new plant parameters: Double plant, Custom sound set, Creative pick item, Placing condition, Custom
+  set of blocks a plant can be placed/grow on, On block added and On block placed by triggers
 * Added support for a new tool parameter: When block destroyed with tool trigger
 * Added support for new enchantment features
 * Added support for new ranged item parameters: Action sound and animation
@@ -60,7 +86,9 @@ Note: Incompatible with MCreator 2021.2.31709 and older
 * [Bugfix] Some other minor fixes and improvements
 
 ## 1.3
+
 Note: Except if a major bug is found, this version is the last one supporting MCreator 2021.1.
+
 * Added custom structure spawn mod element
 * Added custom particle mod element
 * Added Particle properties support for blocks
@@ -71,9 +99,11 @@ Note: Except if a major bug is found, this version is the last one supporting MC
 * [Bugfix #133] Spawn XP orb and Add enchantment to itemstack procedure blocks caused a build error
 
 ## 1.2
-Note: This version will not be loaded on MCreator 2021.2 (including snapshots). 
-2021.2 snapshots make several major changes, making the current version incompatible with them.
-Another version will be made to support entirely MCreator 2021.2
+
+Note: This version will not be loaded on MCreator 2021.2 (including snapshots). 2021.2 snapshots make several major
+changes, making the current version incompatible with them. Another version will be made to support entirely MCreator
+2021.2
+
 * Updated to Fabric API 0.37.1
 * Improved generated code for custom armors
 * Added support for the painting mod element
@@ -84,38 +114,44 @@ Another version will be made to support entirely MCreator 2021.2
 * [Bugfix #131] Blocks and items did not appear in custom creative tabs
 
 ## 1.1
+
 ### Release
+
 * Updated Fabric API to 0.34.6
 * Added a complete support for the game rule mod element
 * Added support for block generation parameters
-* Added support for all plant generation types and generation parameters  
-* Added new world procedure blocks: get logic game rule, get number game rule, set logic game rule and set number game rule
+* Added support for all plant generation types and generation parameters
+* Added new world procedure blocks: get logic game rule, get number game rule, set logic game rule and set number game
+  rule
 * Added complete support for Tick randomly
 * Added a new block trigger: Update tick
-* Updated the tag mod element to support entities  
+* Updated the tag mod element to support entities
 * Added new block bases: [#104] Stairs, door, fence, fence gate
 * [Bugfix #110] GROUND and PLANT step sounds had the wrong sound.
 * [Bugfix] Transparency on custom plants was black.
 * [Bugfix] Update tick trigger for plants caused a build error.
 
 ### Snapshot 1
-* [#83] Added support for custom living entities
-  Note: Flying entities are not 100% implemented. Entity inventory and Ranged attacks are not implemented.
+
+* [#83] Added support for custom living entities Note: Flying entities are not 100% implemented. Entity inventory and
+  Ranged attacks are not implemented.
 * Added minimum and maximal enchantment level parameters
 * Added Enable melee damage checkbox for custom items
 * [Bugfix #102] Some block triggers caused build errors
-* [Bugfix #105] Blocks mined with a tool using a lower harvest level dropped. 
+* [Bugfix #105] Blocks mined with a tool using a lower harvest level dropped.
 * [Bugfix] Some sound mappings did not work properly
 
 ## 1.0.2
+
 * [Bugfix #99] Repair items could not use custom tools
 * [Bugfix #101] Select a map color on custom blocks caused a build error
 * [Bugfix #102] Some block triggers caused build errors
-* [Bugfix #102] Several world procedure blocks caused a build error  
-* [Bugfix] Some Material mappings were wrong  
+* [Bugfix #102] Several world procedure blocks caused a build error
+* [Bugfix] Some Material mappings were wrong
 * [Bugfix] Custom plants prevented the workspace compilation
 
 ## 1.0.1
+
 * Updated to MCreator EAP 2021.12313
 * Updated Fabric API to 0.32.5
 * Updated the command mod element to support new features
@@ -128,38 +164,40 @@ Another version will be made to support entirely MCreator 2021.2
 * [Bugfix] An error was still printed in the console saying custom trees are not supported yet.
 
 ## 1.0
+
 * The plugin no longer requires ClothCommons to work
 * Updated to MCreator 2021.1.3117
 * Updated to Minecraft 1.16.5
 * Updated Fabric API to 0.32.0
 * Added support for custom potions
 * Added support for custom dimensions (no portal)
-* Updated the biome, command, food, loot table and overlay to support new features
-  //Note for biomes: The biome dictionary is not supported because fabric doesn't support for the moment. Check below for custom trees 
-  //Note for foods: When item is dropped and When entity swing item are still not implemented)
+* Updated the biome, command, food, loot table and overlay to support new features //Note for biomes: The biome
+  dictionary is not supported because fabric doesn't support for the moment. Check below for custom trees //Note for
+  foods: When item is dropped and When entity swing item are still not implemented)
 * Added support for slab, leaves and pane block bases
-* Added support for custom trees in biomes
-  //Note: Max water depth, custom vines and fruits are not implemented yet (water depth is not supported)
+* Added support for custom trees in biomes //Note: Max water depth, custom vines and fruits are not implemented yet (
+  water depth is not supported)
 * Added the smithing recipe type
 * Added support for local variables in procedures
 * Added crop model for blocks
 * Added support for custom block item and particle textures
 * Added Is immune to fire, glow condition, recipe remainder, rarity
-* Added support for new item stack related procedure blocks: Is enchanted, Is enchantable, Has enchantment, Set number of items to,
-  Cooldown for, Get damage, Get enchantment level, Provided itemstack
+* Added support for new item stack related procedure blocks: Is enchanted, Is enchantable, Has enchantment, Set number
+  of items to, Cooldown for, Get damage, Get enchantment level, Provided itemstack
 * Added support for the Return and Console log procedure blocks
-* Explode procedure block now supports the explosion type  
+* Explode procedure block now supports the explosion type
 * Biomes can now be generated in the overworld
 * Added all missing mappings and fixed some mapping files
 * Remove mixins entirely
-* Custom axes, pickaxes, swords, shovels and hoes have now to be added inside the fabric item tag to work with modded blocks
-  //Note: Item tags: fabric:axes, fabric:pickaxes, fabric:swords, fabric:shovels and fabric:hoes
-  //Without this change, files have to be manually changed to remove the "null" each type a custom tool is deleted.
+* Custom axes, pickaxes, swords, shovels and hoes have now to be added inside the fabric item tag to work with modded
+  blocks //Note: Item tags: fabric:axes, fabric:pickaxes, fabric:swords, fabric:shovels and fabric:hoes //Without this
+  change, files have to be manually changed to remove the "null" each type a custom tool is deleted.
 * [Bugfix] Mods couldn't be exported
 * [Bugfix] Run client could not work
 * [Bugfix] Fix transparency parameter for blocks
 * [Bugfix] Blocks didn't build properly
-* [Bugfix] Tools failed to compile when the attack speed was set to a decimal, and the damage would be reduced by the attack speed.
+* [Bugfix] Tools failed to compile when the attack speed was set to a decimal, and the damage would be reduced by the
+  attack speed.
 * [Bugfix] Surely more bug fix caused by mixins
 * [Bugfix] Custom armors had a black and white renderer
 * [Bugfix] Custom armors without an equipment sound or with an invalid sound caused a build error
@@ -169,25 +207,31 @@ Another version will be made to support entirely MCreator 2021.2
 * [Bugfix] Fix custom enchantments in mappings
 
 ## 1.0.0-pre6
+
 * Updated to the second 2020.5 snapshot
 * Started to update biomes to the second 2020.5 snapshot. (Structures and Default Features)
-* [Bugfix] Blocks Break Thread Three Fix #74 and #80 
+* [Bugfix] Blocks Break Thread Three Fix #74 and #80
 
 ## 1.0.0-pre5
-* Added overworld biome generation. 
+
+* Added overworld biome generation.
 
 ## 1.0.0-pre4
+
 * Updated to 1.16.3
 * [Bugfix] Fixed a crash with modmenu
 
 ## 1.0.0-pre3
+
 * Updated to 1.16.3 rc-1
 * Re-added modmenu support
 
 ## 1.0.0-pre2
+
 * Added Ranged Item mod element.
 
 ## 1.0.0-pre1
+
 * Added Plant mod element
 * Added Biome mod element
 * Added the damage vs mob/animal for items (#68)
@@ -197,12 +241,14 @@ Another version will be made to support entirely MCreator 2021.2
 * [Bugfix] Fixed commands (fixes #65)
 
 ## 1.0.0-alpha5
+
 - Updated Fabric, Fabric API and mapping versions
 - [Bugfix #45]  Procedures didn't compile properly (#57)
 - [Bugfix #50] Food elements didn't compile properly (#59)
 - Added emissive lighting for blocks (#59)
 
 ## 1.0.0-alpha4
+
 The plugins now require [Cloth Commons](https://github.com/ClothCreators/ClothCommons) to work.
 
 * Added all mappings (1.16.2 and before)
@@ -211,18 +257,22 @@ The plugins now require [Cloth Commons](https://github.com/ClothCreators/ClothCo
 * [Bugfix #51]
 
 ## 1.0.0-alpha3
+
 - Updated the generator to Minecraft 1.16.2
 - [Bugfix #48]
 
 ## 1.0.0-alpha2
+
 - Added overlays
 - Added music discs
 - Added key bindings (They still have bugs)
 - Added commands
 - Added enchantments
-- [Bugfixes] Fixed all (or almost, an option for the items has been deactivated for the moment) elements of the first alpha version.
+- [Bugfixes] Fixed all (or almost, an option for the items has been deactivated for the moment) elements of the first
+  alpha version.
 
 ## 1.0.0-alpha1
+
 - Items (inventory is not supported yet)
 - Blocks (block entities are not supported yet)
 - Armor
@@ -239,12 +289,15 @@ The plugins now require [Cloth Commons](https://github.com/ClothCreators/ClothCo
 - Tags
 
 ## 0.6.1
+
 * [Bugfix #32]
 * [Bugfix #33]
 * Updated fabric API
 
 ## 0.6.0
+
 ### All Changes:-
+
 * **Added support for Non-pushable block entities**
 * **Armor can now use custom sounds**
 * **Added support for Falling blocks**
@@ -252,11 +305,12 @@ The plugins now require [Cloth Commons](https://github.com/ClothCreators/ClothCo
 * **Added support for directional properties on blocks (all five of them)**
 * **Added support for custom voxelshapes that work with directional blocks**
 * **Added support for custom biomes**
-* **Added support for Ore generation. This is very incomplete and  works only in the nether and overworld, and replaces netherrack and the 4 stone variants respectively**
+* **Added support for Ore generation. This is very incomplete and works only in the nether and overworld, and replaces
+  netherrack and the 4 stone variants respectively**
 * **Added support for the creation of plants**. Features:
-  * Offset type
-  * All other implemented block properties
-  * Unbreakability
+    * Offset type
+    * All other implemented block properties
+    * Unbreakability
 * Added support for Item, Block and Food tooltips
 * Added support for enchantment glint on Items and Food
 * Added support for drinking on food (drinking means different sounds and no particles)
@@ -276,11 +330,13 @@ The plugins now require [Cloth Commons](https://github.com/ClothCreators/ClothCo
 * Updated yarn version
 
 ### Changes from the previous snapshot:-
+
 * Fixed a critical bug with biomes
 * Optimized code
 * Updated fabric loader to 0.8.8
 
 ## 0.5.0
+
 - **Updated Fabric API version to 0.11.1+build.312-1.15**
 - **Updated the Fabric version for 0.8.7+build.201 (If you get an error with the setup, Re-run the setup.)**
 - Updated yarn mappings for the 1.15.2+build.17 version
@@ -293,35 +349,40 @@ The plugins now require [Cloth Commons](https://github.com/ClothCreators/ClothCo
 - **[Bugfix #5] Smelting, Blasting, Smoking, Campfire recipe types didn't work.**
 
 ## 0.4.1
+
 * [Bugfix] Fixed some block materials having wrong mapping names
 * [Bugfix] Fixed block sounds having wrong mapping names
 * Added more block materials
 * Changed block materials
 
 ## 0.4.0
+
 * Added support for tools (Pickaxe, Axe, Shovel, and Sword)
 * Added support for the maximal damage for items
-* The generator has now its own workspace type. Your old workspaces can be broken. It is recommended to create a new workspace.
+* The generator has now its own workspace type. Your old workspaces can be broken. It is recommended to create a new
+  workspace.
 * Removed Block Render (Didn't work)
 * [Bugfix] Fixed Fuel element
 * [Bugfix] The main class had nothing inside if you make a block
 * [Bugfix] Fixed Block element
 
 ## 0.3.0
+
 * Added Basic Block Element:
-  * Render (Solid, cutout, cutout mipped, and translucent)
-  * Hardness/Resistance/Material/Sound/Creative tab
-  * Generation in the world (Specific biomes don’t work)
+    * Render (Solid, cutout, cutout mipped, and translucent)
+    * Hardness/Resistance/Material/Sound/Creative tab
+    * Generation in the world (Specific biomes don’t work)
 * Added Food Element (Few parameters don’t work)
 * Added Fuel Element
 
-
 ## 0.2.1
+
 * [Bugfix] Fixed bugs
 * Removed ItemGroup feature, will be re-added later
 * Added Recipe, Tag, Function, Advancement, and Loot Table Features
 
 ## 0.2.0
+
 * Added Basic Creative Tabs
 * Added Advancements
 * Added Loot Tables
@@ -330,4 +391,5 @@ The plugins now require [Cloth Commons](https://github.com/ClothCreators/ClothCo
 * Added Recipes
 
 ## 0.1.0
+
 * Basic item support

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 ## 1.5
 * Added full support for custom GUIs
 * Added support for following GUI related procedure blocks: Get text in textfield, Is checkbox checked, Set text in textfield
+* [Bugfix] Using the custom drop option in custom blocks caused a build error (due to a changed from the last version)
+* [Bugfix] On block right-clicked block trigger caused a build error
+* [Bugfix] Right-click in air item trigger caused a build error.
 
 ## 1.4.2
 * [Bugfix] Custom biome sounds caused a build error

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,7 @@
 # Changelogs:
 ## 1.5
 * Added full support for custom GUIs
+* Added support for Block entity (Block's inventory)
 * Added support for following GUI related procedure blocks: Get text in textfield, Is checkbox checked, Set text in textfield
 * [Bugfix] Using the custom drop option in custom blocks caused a build error (due to a changed from the last version)
 * [Bugfix] On block right-clicked block trigger caused a build error

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 * Added full support for custom GUIs
 * Added support for Block entity (Block's inventory)
 * Added support for item inventory
+* Added support for entity inventory
 * Added support for following GUI related procedure blocks: Get text in textfield, Is checkbox checked, Set text in textfield
 * [Bugfix] Using the custom drop option in custom blocks caused a build error (due to a changed from the last version)
 * [Bugfix] On block right-clicked block trigger caused a build error

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # Changelogs:
 ## 1.5
+* Added full support for custom GUIs
+* Added support for following GUI related procedure blocks: Get text in textfield, Is checkbox checked, Set text in textfield
 * [Bugfix] Custom biome sounds caused a build error
 * [Bugfix] BerryBushes, SwampClayDisk and TaigaLargeFerns default features caused a build due to a wrong value
 * [Bugfix #143] Ray tracing procedure blocks cause a build error

--- a/src/fabric-1.16.5/block.definition.yaml
+++ b/src/fabric-1.16.5/block.definition.yaml
@@ -346,6 +346,5 @@ localizationkeys:
   - key: block.@modid.@registryname
     mapto: name
 
-field_exclusions: [ tintType, isItemTinted, isWaterloggable, displayFluidOverlay, plantsGrowOn, beaconColorModifier, isLadder, enchantPowerBonus, aiPathNodeType, hasInventory,
-                    openGUIOnRightClick, guiBoundTo, inventorySize, inventoryStackSize, inventoryDropWhenDestroyed, inventoryComparatorPower, outSlotIDs, inSlotIDs,
+field_exclusions: [ tintType, isItemTinted, isWaterloggable, displayFluidOverlay, plantsGrowOn, beaconColorModifier, isLadder, enchantPowerBonus, aiPathNodeType,
                     hasEnergyStorage, isFluidTank, energyInitial, energyCapacity, energyMaxReceive, energyMaxExtract, fluidCapacity, fluidRestrictions ]

--- a/src/fabric-1.16.5/gui.definition.yaml
+++ b/src/fabric-1.16.5/gui.definition.yaml
@@ -1,0 +1,5 @@
+templates:
+  - template: gui.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/screen/@NAMEGui.java"
+  - template: gui_window.java.ftl
+    name: "@SRCROOT/@BASEPACKAGEPATH/client/gui/screen/@NAMEGuiWindow.java"

--- a/src/fabric-1.16.5/gui.definition.yaml
+++ b/src/fabric-1.16.5/gui.definition.yaml
@@ -3,3 +3,5 @@ templates:
     name: "@SRCROOT/@BASEPACKAGEPATH/screen/@NAMEGui.java"
   - template: gui_window.java.ftl
     name: "@SRCROOT/@BASEPACKAGEPATH/client/gui/screen/@NAMEGuiWindow.java"
+
+field_exclusions: [onTick]

--- a/src/fabric-1.16.5/item.definition.yaml
+++ b/src/fabric-1.16.5/item.definition.yaml
@@ -15,4 +15,4 @@ localizationkeys:
     mapto: name
 
 field_exclusions: [ onEntitySwing, onDroppedByPlayer, stayInGridWhenCrafting, damageOnCrafting, hasDispenseBehavior, dispenseSuccessCondition,
-                    dispenseResultItemstack, guiBoundTo, inventorySize, inventoryStackSize ]
+                    dispenseResultItemstack ]

--- a/src/fabric-1.16.5/livingentity.definition.yaml
+++ b/src/fabric-1.16.5/livingentity.definition.yaml
@@ -16,4 +16,4 @@ localizationkeys:
   - key: entity.@modid.@registryname
     mapto: mobName
 
-field_exclusions: [ flyingMob, guiBoundTo, inventoryStackSize, inventorySize, spawnInDungeons, ranged, rangedItemType, rangedAttackItem ]
+field_exclusions: [ flyingMob, spawnInDungeons, ranged, rangedItemType, rangedAttackItem ]

--- a/src/fabric-1.16.5/procedures/entity_open_gui.java.ftl
+++ b/src/fabric-1.16.5/procedures/entity_open_gui.java.ftl
@@ -3,9 +3,10 @@
 	Entity _ent = ${input$entity};
 	if(_ent instanceof ServerPlayerEntity) {
 		_ent.openHandledScreen(new ExtendedScreenHandlerFactory() {
+		    BlockPos _pos = new BlockPos((int)${input$x},(int)${input$y},(int)${input$z});
 			@Override
 			public void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf) {
-
+				buf.writeBlockPos(_pos);
 			}
 
 			@Override
@@ -15,7 +16,7 @@
 
 			@Override
 			public ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity player) {
-				return new ${(field$guiname)}Gui.GuiContainerMod(syncId, inv, new PacketByteBuf(Unpooled.buffer()).writeBlockPos(new BlockPos((int)${input$x},(int)${input$y},(int)${input$z})));
+				return new ${(field$guiname)}Gui.GuiContainerMod(syncId, inv, new PacketByteBuf(Unpooled.buffer()).writeBlockPos(_pos));
 			}
 		}
 	}

--- a/src/fabric-1.16.5/procedures/entity_open_gui.java.ftl
+++ b/src/fabric-1.16.5/procedures/entity_open_gui.java.ftl
@@ -1,0 +1,23 @@
+<#-- @formatter:off -->
+{
+	Entity _ent = ${input$entity};
+	if(_ent instanceof ServerPlayerEntity) {
+		_ent.openHandledScreen(new ExtendedScreenHandlerFactory() {
+			@Override
+			public void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf) {
+
+			}
+
+			@Override
+			public Text getDisplayName() {
+				return new LiteralText("${field$guiname}");
+			}
+
+			@Override
+			public ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity player) {
+				return new ${(field$guiname)}Gui.GuiContainerMod(syncId, inv, new PacketByteBuf(Unpooled.buffer()).writeBlockPos(new BlockPos((int)${input$x},(int)${input$y},(int)${input$z})));
+			}
+		}
+	}
+}
+<#-- @formatter:on -->}

--- a/src/fabric-1.16.5/procedures/entity_open_gui.java.ftl
+++ b/src/fabric-1.16.5/procedures/entity_open_gui.java.ftl
@@ -2,7 +2,7 @@
 {
 	Entity _ent = ${input$entity};
 	if(_ent instanceof ServerPlayerEntity) {
-		_ent.openHandledScreen(new ExtendedScreenHandlerFactory() {
+		((ServerPlayerEntity) _ent).openHandledScreen(new ExtendedScreenHandlerFactory() {
 		    BlockPos _pos = new BlockPos((int)${input$x},(int)${input$y},(int)${input$z});
 			@Override
 			public void writeScreenOpeningData(ServerPlayerEntity player, PacketByteBuf buf) {
@@ -18,7 +18,7 @@
 			public ScreenHandler createMenu(int syncId, PlayerInventory inv, PlayerEntity player) {
 				return new ${(field$guiname)}Gui.GuiContainerMod(syncId, inv, new PacketByteBuf(Unpooled.buffer()).writeBlockPos(_pos));
 			}
-		}
+		});
 	}
 }
-<#-- @formatter:on -->}
+<#-- @formatter:on -->

--- a/src/fabric-1.16.5/procedures/gui_damage_item.java.ftl
+++ b/src/fabric-1.16.5/procedures/gui_damage_item.java.ftl
@@ -1,0 +1,16 @@
+if(${input$entity} instanceof ServerPlayerEntity) {
+	ScreenHandler _current = ((ServerPlayerEntity) ${input$entity}).currentScreenHandler;
+	if(_current instanceof Supplier) {
+		Object invobj = ((Supplier) _current).get();
+		if(invobj instanceof Map) {
+			ItemStack stack=((Slot) ((Map) invobj).get((int)(${input$slotid}))).getStack();
+    		if(stack != null) {
+			    if (stack.damage((int) 1, new Random(), null)) {
+				    stack.decrement(1);
+					stack.setDamage(0);
+				}
+				_current.sendContentUpdates();
+    		}
+		}
+	}
+}

--- a/src/fabric-1.16.5/procedures/gui_get_amount_inslot.java.ftl
+++ b/src/fabric-1.16.5/procedures/gui_get_amount_inslot.java.ftl
@@ -1,0 +1,16 @@
+(new Object(){
+	public int getAmount(int sltid) {
+			if(${input$entity} instanceof ServerPlayerEntity) {
+				ScreenHandler _current = ((ServerPlayerEntity) ${input$entity}).currentScreenHandler;
+				if(_current instanceof Supplier) {
+					Object invobj = ((Supplier) _current).get();
+					if(invobj instanceof Map) {
+						ItemStack stack = ((Slot) ((Map) invobj).get(sltid)).getStack();;
+						if(stack != null)
+							return stack.getCount();
+					}
+				}
+			}
+			return 0;
+		}
+}.getAmount((int)(${input$slotid})))

--- a/src/fabric-1.16.5/procedures/gui_get_item_inslot.java.ftl
+++ b/src/fabric-1.16.5/procedures/gui_get_item_inslot.java.ftl
@@ -1,0 +1,15 @@
+/*@ItemStack*/(new Object(){
+	public ItemStack getItemStack(int sltid) {
+			Entity _ent = ${input$entity};
+			if(_ent instanceof ServerPlayerEntity) {
+				ScreenHandler _current = ((ServerPlayerEntity) _ent).currentScreenHandler;
+				if(_current instanceof Supplier) {
+					Object invobj = ((Supplier) _current).get();
+					if(invobj instanceof Map) {
+						return ((Slot) ((Map) invobj).get(sltid)).getStack();
+					}
+				}
+			}
+			return ItemStack.EMPTY;
+		}
+	}.getItemStack((int)(${input$slotid})))

--- a/src/fabric-1.16.5/procedures/gui_get_text_textfield.java.ftl
+++ b/src/fabric-1.16.5/procedures/gui_get_text_textfield.java.ftl
@@ -1,0 +1,9 @@
+(new Object(){
+	public String getText(){
+		TextFieldWidget _tf = (TextFieldWidget) guistate.get("text:${field$textfield}");
+		if(_tf!=null){
+			return _tf.getText();
+		}
+		return"";
+	}
+}.getText())

--- a/src/fabric-1.16.5/procedures/gui_get_value_checkbox.java.ftl
+++ b/src/fabric-1.16.5/procedures/gui_get_value_checkbox.java.ftl
@@ -1,0 +1,9 @@
+(new Object(){
+	public boolean getValue(){
+		CheckboxWidget checkbox = (CheckboxWidget)guistate.get("checkbox:${field$checkbox}");
+		if(checkbox!=null){
+			return checkbox.isChecked();
+		}
+		return false;
+	}
+}.getValue())

--- a/src/fabric-1.16.5/procedures/gui_remove_items.java.ftl
+++ b/src/fabric-1.16.5/procedures/gui_remove_items.java.ftl
@@ -1,0 +1,13 @@
+{
+	Entity _ent = ${input$entity};
+	if(_ent instanceof ServerPlayerEntity) {
+		ScreenHandler _current = ((ServerPlayerEntity) _ent).currentScreenHandler;
+		if(_current instanceof Supplier) {
+			Object invobj = ((Supplier) _current).get();
+			if(invobj instanceof Map) {
+				((Slot) ((Map) invobj).get((int)(${input$slotid}))).takeStack((int)(${input$amount}));
+				_current.sendContentUpdates();
+			}
+		}
+	}
+}

--- a/src/fabric-1.16.5/procedures/gui_set_items.java.ftl
+++ b/src/fabric-1.16.5/procedures/gui_set_items.java.ftl
@@ -1,0 +1,13 @@
+<#include "mcitems.ftl">
+if(${input$entity} instanceof PlayerEntity) {
+	ScreenHandler _current = ((PlayerEntity) ${input$entity}).currentScreenHandler;
+	if(_current instanceof Supplier) {
+		Object invobj = ((Supplier) _current).get();
+		if(invobj instanceof Map) {
+			ItemStack _setstack = ${mappedMCItemToItemStackCode(input$item, 1)};
+			_setstack.setCount((int) ${input$amount});
+			((Slot) ((Map) invobj).get((int)(${input$slotid}))).setStack(_setstack);
+			_current.sendContentUpdates();
+		}
+	}
+}

--- a/src/fabric-1.16.5/procedures/gui_set_text_textfield.java.ftl
+++ b/src/fabric-1.16.5/procedures/gui_set_text_textfield.java.ftl
@@ -1,0 +1,6 @@
+{
+	TextFieldWidget _tf = (TextFieldWidget) guistate.get("text:${field$textfield}");
+	if (_tf != null) {
+		_tf.setText(${input$text});
+	}
+}

--- a/src/fabric-1.16.5/templates/gui.java.ftl
+++ b/src/fabric-1.16.5/templates/gui.java.ftl
@@ -163,9 +163,9 @@ public class ${name}Gui {
 
         public static void apply(MinecraftServer server, ServerPlayerEntity entity, ServerPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
 			int buttonID = buf.readInt();
-            int x = buf.readInt();
-            int y = buf.readInt();
-            int z = buf.readInt();
+            double x = buf.readInt();
+            double y = buf.readInt();
+            double z = buf.readInt();
             server.execute(() -> {
                 World world = entity.getServerWorld();
 		        <#assign btid = 0>

--- a/src/fabric-1.16.5/templates/gui.java.ftl
+++ b/src/fabric-1.16.5/templates/gui.java.ftl
@@ -45,26 +45,11 @@ public class ${name}Gui {
 			this.world = inv.player.world;
 			BlockPos pos = null;
 			if (data != null) {
-				pos = entity.getBlockPos();
-				this.x = pos.getX();
-				this.y = pos.getY();
-				this.z = pos.getZ();
-			}
-		}
-
-		public GuiContainerMod(int id, PlayerInventory inv, PlayerEntity player) {
-			super(${JavaModName}.${name}ScreenType, id);
-
-			this.entity = inv.player;
-			this.world = inv.player.world;
-
-			BlockPos pos = null;
-			if (player != null) {
-				pos = player.getBlockPos();
-				this.x = pos.getX();
-				this.y = pos.getY();
-				this.z = pos.getZ();
-			}
+                pos = data.readBlockPos();
+                this.x = pos.getX();
+                this.y = pos.getY();
+                this.z = pos.getZ();
+            }
 
 			<#if hasProcedure(data.onOpen)>
 				<@procedureOBJToCode data.onOpen/>

--- a/src/fabric-1.16.5/templates/gui.java.ftl
+++ b/src/fabric-1.16.5/templates/gui.java.ftl
@@ -29,19 +29,6 @@ public class ${name}Gui {
 
 	public static HashMap guistate = new HashMap();
 
-	<#if hasProcedure(data.onTick)>
-		@SubscribeEvent public void onPlayerTick(TickEvent.PlayerTickEvent event) {
-			PlayerEntity entity = event.player;
-			if(event.phase == TickEvent.Phase.END && entity.openContainer instanceof GuiContainerMod) {
-				World world = entity.world;
-				double x = entity.getPosX();
-				double y = entity.getPosY();
-				double z = entity.getPosZ();
-				<@procedureOBJToCode data.onTick/>
-			}
-		}
-	</#if>
-
 	public static class GuiContainerMod extends ScreenHandler implements Supplier<Map<Integer, Slot>> {
 
 		public World world;
@@ -181,13 +168,13 @@ public class ${name}Gui {
 	}
 
 	public static class ButtonPressedMessage extends PacketByteBuf {
-	    int buttonID;
         public ButtonPressedMessage(int buttonID) {
             super(Unpooled.buffer());
-            this.buttonID = buttonID;
+			writeInt(buttonID);
         }
 
         public static void apply(MinecraftServer server, ServerPlayerEntity entity, ServerPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
+			int buttonID = buf.readInt();
             server.execute(() -> {
                 double x = entity.getX();
                 double y = entity.getY();
@@ -197,7 +184,7 @@ public class ${name}Gui {
                 <#list data.components as component>
                     <#if component.getClass().getSimpleName() == "Button">
 				        <#if hasProcedure(component.onClick)>
-        	    	        if (buf.readByte() == ${btid}) {
+        	    	        if (buttonID == ${btid}) {
         	    	            <@procedureOBJToCode component.onClick/>
 					        }
 				        </#if>

--- a/src/fabric-1.16.5/templates/gui.java.ftl
+++ b/src/fabric-1.16.5/templates/gui.java.ftl
@@ -51,6 +51,106 @@ public class ${name}Gui {
                 this.z = pos.getZ();
             }
 
+			<#if data.type == 1>
+				if (pos != null) {
+					if (data.readableBytes() == 1) { // bound to item
+						byte hand = data.readByte();
+						ItemStack itemstack;
+						if(hand == 0)
+							itemstack = this.entity.getMainHandStack();
+						else
+							itemstack = this.entity.getOffHandStack();
+						itemstack.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(capability -> {
+							this.internal = capability;
+							this.bound = true;
+						});
+					} else if (data.readableBytes() > 1) {
+						data.readByte(); // drop padding
+						Entity entity = world.getEntityById(data.readVarInt());
+						if(entity != null)
+							entity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(capability -> {
+								this.internal = capability;
+								this.bound = true;
+							});
+					} else { // might be bound to block
+						BlockEntity ent = inv.player != null ? inv.player.world.getBlockEntity(pos) : null;
+						if (ent != null) {
+							ent.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(capability -> {
+								this.internal = capability;
+								this.bound = true;
+							});
+						}
+					}
+				}
+
+				<#list data.components as component>
+					<#if component.getClass().getSimpleName()?ends_with("Slot")>
+						<#assign slotnum += 1>
+            	    this.customSlots.put(${component.id}, this.addSlot(new SlotItemHandler(internal, ${component.id},
+						${(component.x - mx / 2)?int + 1},
+						${(component.y - my / 2)?int + 1}) {
+
+            	    	<#if component.disableStackInteraction>
+						@Override public boolean canTakeStack(PlayerEntity player) {
+							return false;
+						}
+            	    	</#if>
+
+						<#if hasProcedure(component.onSlotChanged)>
+            	        @Override public void onSlotChanged() {
+							super.onSlotChanged();
+							GuiContainerMod.this.slotChanged(${component.id}, 0, 0);
+						}
+						</#if>
+
+						<#if hasProcedure(component.onTakenFromSlot)>
+            	        @Override public ItemStack onTake(PlayerEntity entity, ItemStack stack) {
+							ItemStack retval = super.onTake(entity, stack);
+							GuiContainerMod.this.slotChanged(${component.id}, 1, 0);
+							return retval;
+						}
+						</#if>
+
+						<#if hasProcedure(component.onStackTransfer)>
+            	        @Override public void onSlotChange(ItemStack a, ItemStack b) {
+							super.onSlotChange(a, b);
+							GuiContainerMod.this.slotChanged(${component.id}, 2, b.getCount() - a.getCount());
+						}
+						</#if>
+
+						<#if component.disableStackInteraction>
+							@Override public boolean isItemValid(ItemStack stack) {
+								return false;
+							}
+            	        <#elseif component.getClass().getSimpleName() == "InputSlot">
+							<#if component.inputLimit.toString()?has_content>
+            	             @Override public boolean isItemValid(ItemStack stack) {
+								 return (${mappedMCItemToItem(component.inputLimit)} == stack.getItem());
+							 }
+							</#if>
+						<#elseif component.getClass().getSimpleName() == "OutputSlot">
+            	            @Override public boolean isItemValid(ItemStack stack) {
+								return false;
+							}
+						</#if>
+					}));
+					</#if>
+				</#list>
+
+				<#assign coffx = ((data.width - 176) / 2 + data.inventoryOffsetX)?int>
+				<#assign coffy = ((data.height - 166) / 2 + data.inventoryOffsetY)?int>
+
+            	int si;
+				int sj;
+
+				for (si = 0; si < 3; ++si)
+					for (sj = 0; sj < 9; ++sj)
+						this.addSlot(new Slot(inv, sj + (si + 1) * 9, ${coffx} + 8 + sj * 18, ${coffy}+ 84 + si * 18));
+
+				for (si = 0; si < 9; ++si)
+					this.addSlot(new Slot(inv, si, ${coffx} + 8 + si * 18, ${coffy} + 142));
+			</#if>
+
 			<#if hasProcedure(data.onOpen)>
 				<@procedureOBJToCode data.onOpen/>
 			</#if>
@@ -66,26 +166,26 @@ public class ${name}Gui {
 		}
 
 		<#if data.type == 1>
-		@Override public ItemStack transferStackInSlot(PlayerEntity playerIn, int index) {
+		@Override public ItemStack transferSlot(PlayerEntity playerIn, int index) {
 			ItemStack itemstack = ItemStack.EMPTY;
-			Slot slot = (Slot) this.inventorySlots.get(index);
+			Slot slot = (Slot) this.slots.get(index);
 
-			if (slot != null && slot.getHasStack()) {
+			if (slot != null && slot.hasStack()) {
 				ItemStack itemstack1 = slot.getStack();
 				itemstack = itemstack1.copy();
 
 				if (index < ${slotnum}) {
-					if (!this.mergeItemStack(itemstack1, ${slotnum}, this.inventorySlots.size(), true)) {
+					if (!this.insertItem(itemstack1, ${slotnum}, this.slots.size(), true)) {
 						return ItemStack.EMPTY;
 					}
-					slot.onSlotChange(itemstack1, itemstack);
-				} else if (!this.mergeItemStack(itemstack1, 0, ${slotnum}, false)) {
+					slot.onQuickTransfer(itemstack1, itemstack);
+				} else if (!this.insertItem(itemstack1, 0, ${slotnum}, false)) {
 					if (index < ${slotnum} + 27) {
-						if (!this.mergeItemStack(itemstack1, ${slotnum} + 27, this.inventorySlots.size(), true)) {
+						if (!this.insertItem(itemstack1, ${slotnum} + 27, this.slots.size(), true)) {
 							return ItemStack.EMPTY;
 						}
 					} else {
-						if (!this.mergeItemStack(itemstack1, ${slotnum}, ${slotnum} + 27, false)) {
+						if (!this.insertItem(itemstack1, ${slotnum}, ${slotnum} + 27, false)) {
 							return ItemStack.EMPTY;
 						}
 					}
@@ -93,59 +193,134 @@ public class ${name}Gui {
 				}
 
 				if (itemstack1.getCount() == 0) {
-					slot.putStack(ItemStack.EMPTY);
+					slot.setStack(ItemStack.EMPTY);
 				} else {
-					slot.onSlotChanged();
+					slot.markDirty();
 				}
 
 				if (itemstack1.getCount() == itemstack.getCount()) {
 					return ItemStack.EMPTY;
 				}
 
-				slot.onTake(playerIn, itemstack1);
+				slot.onTakeItem(playerIn, itemstack1);
 			}
 			return itemstack;
 		}
 
-		<#-- #47997 -->
-		@Override ${mcc.getMethod("net.minecraft.inventory.container.Container", "mergeItemStack", "ItemStack", "int", "int", "boolean")
-			.replace("slot.onSlotChanged();", "slot.putStack(itemstack);")
-			.replace("!itemstack.isEmpty()", "slot.isItemValid(itemstack) && !itemstack.isEmpty()")}
+		@Override
+		protected boolean insertItem(ItemStack stack, int startIndex, int endIndex, boolean fromLast) {
+            boolean bl = false;
+            int i = startIndex;
+            if (fromLast) {
+            	i = endIndex - 1;
+            }
 
-		@Override public void onContainerClosed(PlayerEntity playerIn) {
-			super.onContainerClosed(playerIn);
+            Slot slot2;
+            ItemStack itemStack;
+            if (stack.isStackable()) {
+            	while(!stack.isEmpty()) {
+            		if (fromLast) {
+            			if (i < startIndex) {
+            				break;
+            			}
+            		} else if (i >= endIndex) {
+            			break;
+            		}
+
+            		slot2 = (Slot)this.slots.get(i);
+            		itemStack = slot2.getStack();
+            		if (slot2.canInsert(itemStack) && !itemStack.isEmpty()) {
+            			int j = itemStack.getCount() + stack.getCount();
+            			if (j <= stack.getMaxCount()) {
+            				stack.setCount(0);
+            				itemStack.setCount(j);
+            				slot2.setStack(itemStack);
+            				bl = true;
+            			} else if (itemStack.getCount() < stack.getMaxCount()) {
+            				stack.decrement(stack.getMaxCount() - itemStack.getCount());
+            				itemStack.setCount(stack.getMaxCount());
+            				slot2.setStack(itemStack);
+            				bl = true;
+            			}
+            		}
+
+            		if (fromLast) {
+            			--i;
+            		} else {
+            			++i;
+            		}
+            	}
+            }
+
+            if (!stack.isEmpty()) {
+            	if (fromLast) {
+            		i = endIndex - 1;
+            	} else {
+            		i = startIndex;
+            	}
+
+            	while(true) {
+            		if (fromLast) {
+            			if (i < startIndex) {
+            				break;
+            			}
+            		} else if (i >= endIndex) {
+            			break;
+            		}
+
+            		slot2 = (Slot)this.slots.get(i);
+            		itemStack = slot2.getStack();
+            		if (itemStack.isEmpty() && slot2.canInsert(stack)) {
+            			if (stack.getCount() > slot2.getMaxItemCount()) {
+            				slot2.setStack(stack.split(slot2.getMaxItemCount()));
+            			} else {
+            				slot2.setStack(stack.split(stack.getCount()));
+            			}
+
+            			slot2.setStack(itemStack);
+            			bl = true;
+            			break;
+            		}
+
+            		if (fromLast) {
+            			--i;
+            		} else {
+            			++i;
+            		}
+            	}
+            }
+
+            return bl;
+        }
+
+		@Override
+		public void close(PlayerEntity playerIn) {
+			super.close(playerIn);
 
 			<#if hasProcedure(data.onClosed)>
 				<@procedureOBJToCode data.onClosed/>
 			</#if>
 
 			if (!bound && (playerIn instanceof ServerPlayerEntity)) {
-				if (!playerIn.isAlive() || playerIn instanceof ServerPlayerEntity && ((ServerPlayerEntity)playerIn).hasDisconnected()) {
-					for(int j = 0; j < internal.getSlots(); ++j) {
+				if (!playerIn.isAlive() || playerIn instanceof ServerPlayerEntity && ((ServerPlayerEntity)playerIn).isDisconnected()) {
+					for(int j = 0; j < slots.size(); ++j) {
 						<#list data.components as component>
 							<#if component.getClass().getSimpleName()?ends_with("Slot") && !component.dropItemsWhenNotBound>
 								if(j == ${component.id}) continue;
 							</#if>
 						</#list>
-						playerIn.dropItem(internal.extractItem(j, internal.getStackInSlot(j).getCount(), false), false);
+						playerIn.dropItem(slots.get(j).takeStack(slots.get(j).getStack().getCount()), false);
 					}
 				} else {
-					for(int i = 0; i < internal.getSlots(); ++i) {
+					for(int i = 0; i < slots.size(); ++i) {
 						<#list data.components as component>
 							<#if component.getClass().getSimpleName()?ends_with("Slot") && !component.dropItemsWhenNotBound>
 								if(i == ${component.id}) continue;
 							</#if>
 						</#list>
-						playerIn.inventory.placeItemBackInInventory(playerIn.world, internal.extractItem(i, internal.getStackInSlot(i).getCount(), false));
+						playerIn.inventory.offerOrDrop(playerIn.world, slots.get(i).takeStack(slots.get(i).getStack().getCount()));
 					}
 				}
-			}
-		}
-
-		private void slotChanged(int slotid, int ctype, int meta) {
-			if(this.world != null && this.world.isRemote()) {
-				${JavaModName}.PACKET_HANDLER.sendToServer(new GUISlotChangedMessage(slotid, x, y, z, ctype, meta));
-				handleSlotAction(entity, slotid, ctype, meta, x, y, z);
 			}
 		}
 

--- a/src/fabric-1.16.5/templates/gui.java.ftl
+++ b/src/fabric-1.16.5/templates/gui.java.ftl
@@ -143,28 +143,45 @@ public class ${name}Gui {
 
 		<#if data.type == 1>
 		@Override
-        public ItemStack transferSlot(PlayerEntity player, int invSlot) {
-        	ItemStack newStack = ItemStack.EMPTY;
-        	Slot slot = this.slots.get(invSlot);
-        	if (slot != null && slot.hasStack()) {
-        		ItemStack originalStack = slot.getStack();
-        		newStack = originalStack.copy();
-        		if (invSlot < this.inventory.size()) {
-        			if (!this.insertItem(originalStack, this.inventory.size(), this.slots.size(), true)) {
-        				return ItemStack.EMPTY;
-        			}
-        		} else if (!this.insertItem(originalStack, 0, this.inventory.size(), false)) {
-        			return ItemStack.EMPTY;
-        		}
+        public ItemStack transferSlot(PlayerEntity player, int index) {
+			ItemStack itemstack = ItemStack.EMPTY;
+			Slot slot = (Slot) this.slots.get(index);
 
-        		if (originalStack.isEmpty()) {
-        			slot.setStack(ItemStack.EMPTY);
-        		} else {
-        			slot.markDirty();
-        		}
-        	}
+			if (slot != null && slot.hasStack()) {
+				ItemStack itemstack1 = slot.getStack();
+				itemstack = itemstack1.copy();
 
-        	return newStack;
+				if (index < ${slotnum}) {
+					if (!this.insertItem(itemstack1, ${slotnum}, this.slots.size(), true)) {
+						return ItemStack.EMPTY;
+					}
+					slot.onSlotChange(itemstack1, itemstack);
+				} else if (!this.insertItem(itemstack1, 0, ${slotnum}, false)) {
+					if (index < ${slotnum} + 27) {
+						if (!this.insertItem(itemstack1, ${slotnum} + 27, this.slots.size(), true)) {
+							return ItemStack.EMPTY;
+						}
+					} else {
+						if (!this.insertItem(itemstack1, ${slotnum}, ${slotnum} + 27, false)) {
+							return ItemStack.EMPTY;
+						}
+					}
+					return ItemStack.EMPTY;
+				}
+
+				if (itemstack1.getCount() == 0) {
+					slot.setStack(ItemStack.EMPTY);
+				} else {
+					slot.markDirty();
+				}
+
+				if (itemstack1.getCount() == itemstack.getCount()) {
+					return ItemStack.EMPTY;
+				}
+
+				slot.onTakeItem(player, itemstack1);
+			}
+			return itemstack;
         }
 
 		@Override

--- a/src/fabric-1.16.5/templates/gui.java.ftl
+++ b/src/fabric-1.16.5/templates/gui.java.ftl
@@ -155,7 +155,7 @@ public class ${name}Gui {
 					if (!this.insertItem(itemstack1, ${slotnum}, this.slots.size(), true)) {
 						return ItemStack.EMPTY;
 					}
-					slot.onSlotChange(itemstack1, itemstack);
+					slot.onQuickTransfer(itemstack1, itemstack);
 				} else if (!this.insertItem(itemstack1, 0, ${slotnum}, false)) {
 					if (index < ${slotnum} + 27) {
 						if (!this.insertItem(itemstack1, ${slotnum} + 27, this.slots.size(), true)) {

--- a/src/fabric-1.16.5/templates/gui.java.ftl
+++ b/src/fabric-1.16.5/templates/gui.java.ftl
@@ -153,17 +153,20 @@ public class ${name}Gui {
 	}
 
 	public static class ButtonPressedMessage extends PacketByteBuf {
-        public ButtonPressedMessage(int buttonID) {
+        public ButtonPressedMessage(int buttonID, int x, int y, int z) {
             super(Unpooled.buffer());
 			writeInt(buttonID);
+			writeInt(x);
+			writeInt(y);
+			writeInt(z);
         }
 
         public static void apply(MinecraftServer server, ServerPlayerEntity entity, ServerPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
 			int buttonID = buf.readInt();
+            int x = buf.readInt();
+            int y = buf.readInt();
+            int z = buf.readInt();
             server.execute(() -> {
-                double x = entity.getX();
-                double y = entity.getY();
-                double z = entity.getZ();
                 World world = entity.getServerWorld();
 		        <#assign btid = 0>
                 <#list data.components as component>

--- a/src/fabric-1.16.5/templates/gui.java.ftl
+++ b/src/fabric-1.16.5/templates/gui.java.ftl
@@ -1,0 +1,450 @@
+<#--
+This file is part of Fabric-Generator-MCreator.
+
+Fabric-Generator-MCreator is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Fabric-Generator-MCreator is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with Fabric-Generator-MCreator.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<#-- @formatter:off -->
+<#include "mcitems.ftl">
+<#include "procedures.java.ftl">
+
+<#assign mx = data.W - data.width>
+<#assign my = data.H - data.height>
+<#assign slotnum = 0>
+
+package ${package}.screen;
+
+@${JavaModName}Elements.ModElement.Tag public class ${name}Gui extends ${JavaModName}Elements.ModElement {
+
+	public static HashMap guistate = new HashMap();
+
+	private static ContainerType<GuiContainerMod> containerType = null;
+
+	public ${name}Gui(${JavaModName}Elements instance) {
+		super(instance, ${data.getModElement().getSortID()});
+
+		elements.addNetworkMessage(ButtonPressedMessage.class, ButtonPressedMessage::buffer, ButtonPressedMessage::new, ButtonPressedMessage::handler);
+		elements.addNetworkMessage(GUISlotChangedMessage.class, GUISlotChangedMessage::buffer, GUISlotChangedMessage::new, GUISlotChangedMessage::handler);
+
+		containerType = new ContainerType<>(new GuiContainerModFactory());
+
+		FMLJavaModLoadingContext.get().getModEventBus().register(new ContainerRegisterHandler());
+
+		<#if hasProcedure(data.onTick)>
+		MinecraftForge.EVENT_BUS.register(this);
+		</#if>
+	}
+
+	private static class ContainerRegisterHandler {
+
+		@SubscribeEvent public void registerContainer(RegistryEvent.Register<ContainerType<?>> event) {
+			event.getRegistry().register(containerType.setRegistryName("${registryname}"));
+		}
+
+	}
+
+	@OnlyIn(Dist.CLIENT) public void initElements() {
+		DeferredWorkQueue.runLater(() -> ScreenManager.registerFactory(containerType, ${name}GuiWindow::new));
+	}
+
+	<#if hasProcedure(data.onTick)>
+		@SubscribeEvent public void onPlayerTick(TickEvent.PlayerTickEvent event) {
+			PlayerEntity entity = event.player;
+			if(event.phase == TickEvent.Phase.END && entity.openContainer instanceof GuiContainerMod) {
+				World world = entity.world;
+				double x = entity.getPosX();
+				double y = entity.getPosY();
+				double z = entity.getPosZ();
+				<@procedureOBJToCode data.onTick/>
+			}
+		}
+	</#if>
+
+	public static class GuiContainerModFactory implements IContainerFactory {
+
+		public GuiContainerMod create(int id, PlayerInventory inv, PacketByteBuf extraData) {
+			return new GuiContainerMod(id, inv, extraData);
+		}
+
+	}
+
+	public static class GuiContainerMod extends Container implements Supplier<Map<Integer, Slot>> {
+
+		World world;
+		PlayerEntity entity;
+		int x, y, z;
+
+		private IItemHandler internal;
+
+		private Map<Integer, Slot> customSlots = new HashMap<>();
+
+		private boolean bound = false;
+
+		public GuiContainerMod(int id, PlayerInventory inv, PacketByteBuf extraData) {
+			super(containerType, id);
+
+			this.entity = inv.player;
+			this.world = inv.player.world;
+
+			this.internal = new ItemStackHandler(${data.getMaxSlotID() + 1});
+
+			BlockPos pos = null;
+			if (extraData != null) {
+				pos = extraData.readBlockPos();
+				this.x = pos.getX();
+				this.y = pos.getY();
+				this.z = pos.getZ();
+			}
+
+			<#if data.type == 1>
+				if (pos != null) {
+					if (extraData.readableBytes() == 1) { // bound to item
+						byte hand = extraData.readByte();
+						ItemStack itemstack;
+						if(hand == 0)
+							itemstack = this.entity.getHeldItemMainhand();
+						else
+							itemstack = this.entity.getHeldItemOffhand();
+						itemstack.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(capability -> {
+							this.internal = capability;
+							this.bound = true;
+						});
+					} else if (extraData.readableBytes() > 1) {
+						extraData.readByte(); // drop padding
+						Entity entity = world.getEntityByID(extraData.readVarInt());
+						if(entity != null)
+							entity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(capability -> {
+								this.internal = capability;
+								this.bound = true;
+							});
+					} else { // might be bound to block
+						TileEntity ent = inv.player != null ? inv.player.world.getTileEntity(pos) : null;
+						if (ent != null) {
+							ent.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY, null).ifPresent(capability -> {
+								this.internal = capability;
+								this.bound = true;
+							});
+						}
+					}
+				}
+
+				<#list data.components as component>
+					<#if component.getClass().getSimpleName()?ends_with("Slot")>
+						<#assign slotnum += 1>
+            	    this.customSlots.put(${component.id}, this.addSlot(new SlotItemHandler(internal, ${component.id},
+						${(component.x - mx / 2)?int + 1},
+						${(component.y - my / 2)?int + 1}) {
+
+            	    	<#if component.disableStackInteraction>
+						@Override public boolean canTakeStack(PlayerEntity player) {
+							return false;
+						}
+            	    	</#if>
+
+						<#if hasProcedure(component.onSlotChanged)>
+            	        @Override public void onSlotChanged() {
+							super.onSlotChanged();
+							GuiContainerMod.this.slotChanged(${component.id}, 0, 0);
+						}
+						</#if>
+
+						<#if hasProcedure(component.onTakenFromSlot)>
+            	        @Override public ItemStack onTake(PlayerEntity entity, ItemStack stack) {
+							ItemStack retval = super.onTake(entity, stack);
+							GuiContainerMod.this.slotChanged(${component.id}, 1, 0);
+							return retval;
+						}
+						</#if>
+
+						<#if hasProcedure(component.onStackTransfer)>
+            	        @Override public void onSlotChange(ItemStack a, ItemStack b) {
+							super.onSlotChange(a, b);
+							GuiContainerMod.this.slotChanged(${component.id}, 2, b.getCount() - a.getCount());
+						}
+						</#if>
+
+						<#if component.disableStackInteraction>
+							@Override public boolean isItemValid(ItemStack stack) {
+								return false;
+							}
+            	        <#elseif component.getClass().getSimpleName() == "InputSlot">
+							<#if component.inputLimit.toString()?has_content>
+            	             @Override public boolean isItemValid(ItemStack stack) {
+								 return (${mappedMCItemToItem(component.inputLimit)} == stack.getItem());
+							 }
+							</#if>
+						<#elseif component.getClass().getSimpleName() == "OutputSlot">
+            	            @Override public boolean isItemValid(ItemStack stack) {
+								return false;
+							}
+						</#if>
+					}));
+					</#if>
+				</#list>
+
+				<#assign coffx = ((data.width - 176) / 2 + data.inventoryOffsetX)?int>
+				<#assign coffy = ((data.height - 166) / 2 + data.inventoryOffsetY)?int>
+
+            	int si;
+				int sj;
+
+				for (si = 0; si < 3; ++si)
+					for (sj = 0; sj < 9; ++sj)
+						this.addSlot(new Slot(inv, sj + (si + 1) * 9, ${coffx} + 8 + sj * 18, ${coffy}+ 84 + si * 18));
+
+				for (si = 0; si < 9; ++si)
+					this.addSlot(new Slot(inv, si, ${coffx} + 8 + si * 18, ${coffy} + 142));
+			</#if>
+
+			<#if hasProcedure(data.onOpen)>
+				<@procedureOBJToCode data.onOpen/>
+			</#if>
+		}
+
+		public Map<Integer, Slot> get() {
+			return customSlots;
+		}
+
+		@Override public boolean canInteractWith(PlayerEntity player) {
+			return true;
+		}
+
+		<#if data.type == 1>
+		@Override public ItemStack transferStackInSlot(PlayerEntity playerIn, int index) {
+			ItemStack itemstack = ItemStack.EMPTY;
+			Slot slot = (Slot) this.inventorySlots.get(index);
+
+			if (slot != null && slot.getHasStack()) {
+				ItemStack itemstack1 = slot.getStack();
+				itemstack = itemstack1.copy();
+
+				if (index < ${slotnum}) {
+					if (!this.mergeItemStack(itemstack1, ${slotnum}, this.inventorySlots.size(), true)) {
+						return ItemStack.EMPTY;
+					}
+					slot.onSlotChange(itemstack1, itemstack);
+				} else if (!this.mergeItemStack(itemstack1, 0, ${slotnum}, false)) {
+					if (index < ${slotnum} + 27) {
+						if (!this.mergeItemStack(itemstack1, ${slotnum} + 27, this.inventorySlots.size(), true)) {
+							return ItemStack.EMPTY;
+						}
+					} else {
+						if (!this.mergeItemStack(itemstack1, ${slotnum}, ${slotnum} + 27, false)) {
+							return ItemStack.EMPTY;
+						}
+					}
+					return ItemStack.EMPTY;
+				}
+
+				if (itemstack1.getCount() == 0) {
+					slot.putStack(ItemStack.EMPTY);
+				} else {
+					slot.onSlotChanged();
+				}
+
+				if (itemstack1.getCount() == itemstack.getCount()) {
+					return ItemStack.EMPTY;
+				}
+
+				slot.onTake(playerIn, itemstack1);
+			}
+			return itemstack;
+		}
+
+		<#-- #47997 -->
+		@Override ${mcc.getMethod("net.minecraft.inventory.container.Container", "mergeItemStack", "ItemStack", "int", "int", "boolean")
+			.replace("slot.onSlotChanged();", "slot.putStack(itemstack);")
+			.replace("!itemstack.isEmpty()", "slot.isItemValid(itemstack) && !itemstack.isEmpty()")}
+
+		@Override public void onContainerClosed(PlayerEntity playerIn) {
+			super.onContainerClosed(playerIn);
+
+			<#if hasProcedure(data.onClosed)>
+				<@procedureOBJToCode data.onClosed/>
+			</#if>
+
+			if (!bound && (playerIn instanceof ServerPlayerEntity)) {
+				if (!playerIn.isAlive() || playerIn instanceof ServerPlayerEntity && ((ServerPlayerEntity)playerIn).hasDisconnected()) {
+					for(int j = 0; j < internal.getSlots(); ++j) {
+						<#list data.components as component>
+							<#if component.getClass().getSimpleName()?ends_with("Slot") && !component.dropItemsWhenNotBound>
+								if(j == ${component.id}) continue;
+							</#if>
+						</#list>
+						playerIn.dropItem(internal.extractItem(j, internal.getStackInSlot(j).getCount(), false), false);
+					}
+				} else {
+					for(int i = 0; i < internal.getSlots(); ++i) {
+						<#list data.components as component>
+							<#if component.getClass().getSimpleName()?ends_with("Slot") && !component.dropItemsWhenNotBound>
+								if(i == ${component.id}) continue;
+							</#if>
+						</#list>
+						playerIn.inventory.placeItemBackInInventory(playerIn.world, internal.extractItem(i, internal.getStackInSlot(i).getCount(), false));
+					}
+				}
+			}
+		}
+
+		private void slotChanged(int slotid, int ctype, int meta) {
+			if(this.world != null && this.world.isRemote()) {
+				${JavaModName}.PACKET_HANDLER.sendToServer(new GUISlotChangedMessage(slotid, x, y, z, ctype, meta));
+				handleSlotAction(entity, slotid, ctype, meta, x, y, z);
+			}
+		}
+
+		</#if>
+	}
+
+	public static class ButtonPressedMessage implements Packet<ServerPlayPacketListener> {
+
+		int buttonID, x, y, z;
+
+		public ButtonPressedMessage(PacketByteBuf buffer) {
+			this.buttonID = buffer.readInt();
+			this.x = buffer.readInt();
+			this.y = buffer.readInt();
+			this.z = buffer.readInt();
+		}
+
+		public ButtonPressedMessage(int buttonID, int x, int y, int z) {
+			this.buttonID = buttonID;
+			this.x = x;
+			this.y = y;
+			this.z = z;
+		}
+
+		public static void buffer(ButtonPressedMessage message, PacketByteBuf buffer) {
+			buffer.writeInt(message.buttonID);
+			buffer.writeInt(message.x);
+			buffer.writeInt(message.y);
+			buffer.writeInt(message.z);
+		}
+
+		public static void handler(ButtonPressedMessage message, Supplier<NetworkEvent.Context> contextSupplier) {
+			NetworkEvent.Context context = contextSupplier.get();
+			context.enqueueWork(() -> {
+				PlayerEntity entity = context.getSender();
+				int buttonID = message.buttonID;
+				int x = message.x;
+				int y = message.y;
+				int z = message.z;
+
+				handleButtonAction(entity, buttonID, x, y, z);
+			});
+			context.setPacketHandled(true);
+		}
+
+	}
+
+	public static class GUISlotChangedMessage {
+
+		int slotID, x, y, z, changeType, meta;
+
+		public GUISlotChangedMessage(int slotID, int x, int y, int z, int changeType, int meta) {
+			this.slotID = slotID;
+			this.x = x;
+			this.y = y;
+			this.z = z;
+			this.changeType = changeType;
+			this.meta = meta;
+		}
+
+		public GUISlotChangedMessage(PacketByteBuf buffer) {
+			this.slotID = buffer.readInt();
+			this.x = buffer.readInt();
+			this.y = buffer.readInt();
+			this.z = buffer.readInt();
+			this.changeType = buffer.readInt();
+			this.meta = buffer.readInt();
+		}
+
+		public static void buffer(GUISlotChangedMessage message, PacketByteBuf buffer) {
+			buffer.writeInt(message.slotID);
+			buffer.writeInt(message.x);
+			buffer.writeInt(message.y);
+			buffer.writeInt(message.z);
+			buffer.writeInt(message.changeType);
+			buffer.writeInt(message.meta);
+		}
+
+		public static void handler(GUISlotChangedMessage message, Supplier<NetworkEvent.Context> contextSupplier) {
+			NetworkEvent.Context context = contextSupplier.get();
+			context.enqueueWork(() -> {
+				PlayerEntity entity = context.getSender();
+				int slotID = message.slotID;
+				int changeType = message.changeType;
+				int meta = message.meta;
+				int x = message.x;
+				int y = message.y;
+				int z = message.z;
+
+				handleSlotAction(entity, slotID, changeType, meta, x, y, z);
+			});
+			context.setPacketHandled(true);
+		}
+
+	}
+
+	static void handleButtonAction(PlayerEntity entity, int buttonID, int x, int y, int z) {
+		World world = entity.world;
+
+		// security measure to prevent arbitrary chunk generation
+		if (!world.isBlockLoaded(new BlockPos(x, y, z)))
+			return;
+
+		<#assign btid = 0>
+        <#list data.components as component>
+			<#if component.getClass().getSimpleName() == "Button">
+				<#if hasProcedure(component.onClick)>
+        	    	if (buttonID == ${btid}) {
+        	    	    <@procedureOBJToCode component.onClick/>
+					}
+				</#if>
+				<#assign btid +=1>
+			</#if>
+		</#list>
+	}
+
+	private static void handleSlotAction(PlayerEntity entity, int slotID, int changeType, int meta, int x, int y, int z) {
+		World world = entity.world;
+
+		// security measure to prevent arbitrary chunk generation
+		if (!world.isBlockLoaded(new BlockPos(x, y, z)))
+			return;
+
+		<#list data.components as component>
+			<#if component.getClass().getSimpleName()?ends_with("Slot")>
+				<#if hasProcedure(component.onSlotChanged)>
+					if (slotID == ${component.id} && changeType == 0) {
+						<@procedureOBJToCode component.onSlotChanged/>
+					}
+				</#if>
+				<#if hasProcedure(component.onTakenFromSlot)>
+					if (slotID == ${component.id} && changeType == 1) {
+						<@procedureOBJToCode component.onTakenFromSlot/>
+					}
+				</#if>
+				<#if hasProcedure(component.onStackTransfer)>
+					if (slotID == ${component.id} && changeType == 2) {
+						int amount = meta;
+						<@procedureOBJToCode component.onStackTransfer/>
+					}
+				</#if>
+			</#if>
+		</#list>
+	}
+
+}
+<#-- @formatter:on -->

--- a/src/fabric-1.16.5/templates/gui_window.java.ftl
+++ b/src/fabric-1.16.5/templates/gui_window.java.ftl
@@ -1,0 +1,214 @@
+<#--
+This file is part of Fabric-Generator-MCreator.
+
+Fabric-Generator-MCreator is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Fabric-Generator-MCreator is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with Fabric-Generator-MCreator.  If not, see <https://www.gnu.org/licenses/>.
+-->
+
+<#-- @formatter:off -->
+<#include "procedures.java.ftl">
+<#include "tokens.ftl">
+
+<#assign mx = data.W - data.width>
+<#assign my = data.H - data.height>
+
+package ${package}.client.gui.screen;
+
+@Environment(EnvType.CLIENT)
+public class ${name}GuiWindow extends HandledScreen<${name}Gui.GuiContainerMod> {
+
+	private World world;
+	private int x, y, z;
+	private PlayerEntity entity;
+
+	private final static HashMap guistate = ${name}Gui.guistate;
+
+	<#list data.components as component>
+		<#if component.getClass().getSimpleName() == "TextField">
+	    TextFieldWidget ${component.name};
+		<#elseif component.getClass().getSimpleName() == "Checkbox">
+	    CheckboxWidget ${component.name};
+		</#if>
+	</#list>
+
+	public ${name}GuiWindow(${name}Gui.GuiContainerMod container, PlayerInventory inventory, Text text) {
+		super(container, inventory, text);
+		this.world = container.world;
+		this.x = container.x;
+		this.y = container.y;
+		this.z = container.z;
+		this.entity = container.entity;
+		this.backgroundWidth = ${data.width};
+		this.backgroundHeight = ${data.height};
+	}
+
+	<#if data.doesPauseGame>
+	@Override public boolean isPauseScreen() {
+		return true;
+	}
+	</#if>
+
+	<#if data.renderBgLayer>
+	private static final Identifier texture = new Identifier("${modid}:textures/${registryname}.png" );
+	</#if>
+
+	@Override public void render(MatrixStack ms, int mouseX, int mouseY, float partialTicks) {
+		this.renderBackground(ms);
+		super.render(ms, mouseX, mouseY, partialTicks);
+		this.drawMouseoverTooltip(ms, mouseX, mouseY);
+
+		<#list data.components as component>
+			<#if component.getClass().getSimpleName() == "TextField">
+				${component.name}.render(ms, mouseX, mouseY, partialTicks);
+			</#if>
+		</#list>
+	}
+
+	@Override protected void drawBackground(MatrixStack ms, float partialTicks, int gx, int gy) {
+		RenderSystem.color4f(1, 1, 1, 1);
+		RenderSystem.enableBlend();
+		RenderSystem.defaultBlendFunc();
+
+		<#if data.renderBgLayer>
+		MinecraftClient.getInstance().getTextureManager().bindTexture(texture);
+		int k = (this.width - this.backgroundWidth) / 2;
+		int l = (this.height - backgroundHeight) / 2;
+		drawTexture(ms, k, l, 0, 0, this.backgroundWidth, backgroundHeight, this.backgroundWidth, backgroundHeight);
+		</#if>
+
+		<#list data.components as component>
+			<#if component.getClass().getSimpleName() == "Image">
+				<#if hasProcedure(component.displayCondition)>if (<@procedureOBJToConditionCode component.displayCondition/>) {</#if>
+					MinecraftClient.getInstance().getTextureManager().bindTexture(new Identifier("${modid}:textures/${component.image}"));
+					drawTexture(ms, this.x + ${(component.x - mx/2)?int}, this.y + ${(component.y - my/2)?int}, 0, 0,
+						${component.getWidth(w.getWorkspace())}, ${component.getHeight(w.getWorkspace())},
+						${component.getWidth(w.getWorkspace())}, ${component.getHeight(w.getWorkspace())});
+				<#if hasProcedure(component.displayCondition)>}</#if>
+			</#if>
+		</#list>
+
+		RenderSystem.disableBlend();
+	}
+
+	@Override public boolean keyPressed(int key, int b, int c) {
+		if (key == 256) {
+			this.client.player.closeScreen();
+			return true;
+		}
+
+		<#list data.components as component>
+			<#if component.getClass().getSimpleName() == "TextField">
+		    if(${component.name}.isFocused())
+		    	return ${component.name}.keyPressed(key, b, c);
+			</#if>
+		</#list>
+
+		return super.keyPressed(key, b, c);
+	}
+
+	@Override public void tick() {
+		super.tick();
+		<#list data.components as component>
+			<#if component.getClass().getSimpleName() == "TextField">
+				${component.name}.tick();
+			</#if>
+		</#list>
+	}
+
+	@Override protected void drawForeground(MatrixStack ms, int mouseX, int mouseY) {
+		<#list data.components as component>
+			<#if component.getClass().getSimpleName() == "Label">
+				<#if hasProcedure(component.displayCondition)>
+				if (<@procedureOBJToConditionCode component.displayCondition/>)
+				</#if>
+		    	this.textRenderer.draw(ms, "${translateTokens(JavaConventions.escapeStringForJava(component.text))}",
+					${(component.x - mx / 2)?int}, ${(component.y - my / 2)?int}, ${component.color.getRGB()});
+			</#if>
+		</#list>
+	}
+
+	@Override public void onClose() {
+		super.onClose();
+		MinecraftClient.getInstance().keyboard.setRepeatEvents(false);
+	}
+
+	@Override public void init(MinecraftClient client, int width, int height) {
+		super.init(client, width, height);
+		client.keyboard.setRepeatEvents(true);
+
+		<#assign btid = 0>
+		<#list data.components as component>
+			<#if component.getClass().getSimpleName() == "TextField">
+				${component.name} = new TextFieldWidget(this.textRenderer, this.x + ${(component.x - mx/2)?int}, this.y + ${(component.y - my/2)?int},
+				${component.width}, ${component.height}, new StringTextComponent("${component.placeholder}"))
+				<#if component.placeholder?has_content>
+				{
+					{
+						setSuggestion("${component.placeholder}");
+					}
+
+					@Override public void writeText(String text) {
+						super.writeText(text);
+
+						if(getText().isEmpty())
+							setSuggestion("${component.placeholder}");
+						else
+							setSuggestion(null);
+					}
+
+					@Override public void setCursorPosition(int pos) {
+						super.setCursorPosition(pos);
+
+						if(getText().isEmpty())
+							setSuggestion("${component.placeholder}");
+						else
+							setSuggestion(null);
+					}
+				}
+				</#if>;
+                guistate.put("text:${component.name}", ${component.name});
+				${component.name}.setMaxStringLength(32767);
+                this.children.add(this.${component.name});
+			<#elseif component.getClass().getSimpleName() == "Button">
+				this.addButton(new ButtonWidget(this.x + ${(component.x - mx/2)?int}, this.y + ${(component.y - my/2)?int},
+					${component.width}, ${component.height}, new LiteralText("${component.text}"), e -> {
+						if (<@procedureOBJToConditionCode component.displayCondition/>) {
+				            ClientPlayNetworkHandler clientPlayNetworkHandler = client.getNetworkHandler();
+						    if (clientPlayNetworkHandler != null) {
+                        	    clientPlayNetworkHandler.sendPacket(new ${name}Gui.ButtonPressedMessage(${btid}, x, y, z));
+                        	    ${name}Gui.handleButtonAction(entity, ${btid}, x, y, z);
+                        	}
+						}
+					}
+				)
+                <#if hasProcedure(component.displayCondition)>
+                {
+					@Override public void render(MatrixStack ms, int gx, int gy, float ticks) {
+						if (<@procedureOBJToConditionCode component.displayCondition/>)
+							super.render(ms, gx, gy, ticks);
+					}
+				}
+				</#if>);
+				<#assign btid +=1>
+			<#elseif component.getClass().getSimpleName() == "Checkbox">
+            	${component.name} = new CheckboxWidget(this.x + ${(component.x - mx/2)?int}, this.y + ${(component.y - my/2)?int},
+            	    150, 20, new LiteralText("${component.text}"), <#if hasProcedure(component.isCheckedProcedure)>
+            	    <@procedureOBJToConditionCode component.isCheckedProcedure/><#else>false</#if>);
+                ${name}Gui.guistate.put("checkbox:${component.name}", ${component.name});
+                this.addButton(${component.name});
+			</#if>
+		</#list>
+	}
+
+}
+<#-- @formatter:on -->

--- a/src/fabric-1.16.5/templates/gui_window.java.ftl
+++ b/src/fabric-1.16.5/templates/gui_window.java.ftl
@@ -183,11 +183,7 @@ public class ${name}GuiWindow extends HandledScreen<${name}Gui.GuiContainerMod> 
 				this.addButton(new ButtonWidget(this.x + ${(component.x - mx/2)?int}, this.y + ${(component.y - my/2)?int},
 					${component.width}, ${component.height}, new LiteralText("${component.text}"), e -> {
 						if (<@procedureOBJToConditionCode component.displayCondition/>) {
-				            ClientPlayNetworkHandler clientPlayNetworkHandler = client.getNetworkHandler();
-						    if (clientPlayNetworkHandler != null) {
-                        	    clientPlayNetworkHandler.sendPacket(new ${name}Gui.ButtonPressedMessage(${btid}, x, y, z));
-                        	    ${name}Gui.handleButtonAction(entity, ${btid}, x, y, z);
-                        	}
+			                ClientPlayNetworking.send(${JavaModName}.id("${name?lower_case}"), new ${name}Gui.ButtonPressedMessage(${btid}));
 						}
 					}
 				)
@@ -208,6 +204,14 @@ public class ${name}GuiWindow extends HandledScreen<${name}Gui.GuiContainerMod> 
                 this.addButton(${component.name});
 			</#if>
 		</#list>
+	}
+
+	public static void screenInit() {
+	<#list data.components as component>
+	<#if component.getClass().getSimpleName() == "Button">
+	    ServerPlayNetworking.registerGlobalReceiver(${JavaModName}.id("${name?lower_case}"), ${name}Gui.ButtonPressedMessage::apply);
+	</#if>
+	</#list>
 	}
 
 }

--- a/src/fabric-1.16.5/templates/gui_window.java.ftl
+++ b/src/fabric-1.16.5/templates/gui_window.java.ftl
@@ -183,7 +183,7 @@ public class ${name}GuiWindow extends HandledScreen<${name}Gui.GuiContainerMod> 
 				this.addButton(new ButtonWidget(this.x + ${(component.x - mx/2)?int}, this.y + ${(component.y - my/2)?int},
 					${component.width}, ${component.height}, new LiteralText("${component.text}"), e -> {
 						if (<@procedureOBJToConditionCode component.displayCondition/>) {
-			                ClientPlayNetworking.send(${JavaModName}.id("${name?lower_case}"), new ${name}Gui.ButtonPressedMessage(${btid}, x, y, z));
+			                ClientPlayNetworking.send(${JavaModName}.id("${name?lower_case}_button_${btid}"), new ${name}Gui.ButtonPressedMessage(${btid}, x, y, z));
 						}
 					}
 				)
@@ -207,9 +207,11 @@ public class ${name}GuiWindow extends HandledScreen<${name}Gui.GuiContainerMod> 
 	}
 
 	public static void screenInit() {
+	<#assign btid = 0>
 	<#list data.components as component>
 	<#if component.getClass().getSimpleName() == "Button">
-	    ServerPlayNetworking.registerGlobalReceiver(${JavaModName}.id("${name?lower_case}"), ${name}Gui.ButtonPressedMessage::apply);
+	    ServerPlayNetworking.registerGlobalReceiver(${JavaModName}.id("${name?lower_case}_button_${btid}"), ${name}Gui.ButtonPressedMessage::apply);
+	    <#assign btid +=1>
 	</#if>
 	</#list>
 	}

--- a/src/fabric-1.16.5/templates/gui_window.java.ftl
+++ b/src/fabric-1.16.5/templates/gui_window.java.ftl
@@ -183,7 +183,7 @@ public class ${name}GuiWindow extends HandledScreen<${name}Gui.GuiContainerMod> 
 				this.addButton(new ButtonWidget(this.x + ${(component.x - mx/2)?int}, this.y + ${(component.y - my/2)?int},
 					${component.width}, ${component.height}, new LiteralText("${component.text}"), e -> {
 						if (<@procedureOBJToConditionCode component.displayCondition/>) {
-			                ClientPlayNetworking.send(${JavaModName}.id("${name?lower_case}"), new ${name}Gui.ButtonPressedMessage(${btid}));
+			                ClientPlayNetworking.send(${JavaModName}.id("${name?lower_case}"), new ${name}Gui.ButtonPressedMessage(${btid}, x, y, z));
 						}
 					}
 				)

--- a/src/fabric-1.16.5/templates/gui_window.java.ftl
+++ b/src/fabric-1.16.5/templates/gui_window.java.ftl
@@ -212,6 +212,8 @@ public class ${name}GuiWindow extends HandledScreen<${name}Gui.GuiContainerMod> 
 	<#if component.getClass().getSimpleName() == "Button">
 	    ServerPlayNetworking.registerGlobalReceiver(${JavaModName}.id("${name?lower_case}_button_${btid}"), ${name}Gui.ButtonPressedMessage::apply);
 	    <#assign btid +=1>
+	<#elseif component.getClass().getSimpleName()?ends_with("Slot")>
+	    ServerPlayNetworking.registerGlobalReceiver(${JavaModName}.id("${name?lower_case}_slot_${component.id}"), ${name}Gui.GUISlotChangedMessage::apply);
 	</#if>
 	</#list>
 	}

--- a/src/fabric-1.16.5/templates/gui_window.java.ftl
+++ b/src/fabric-1.16.5/templates/gui_window.java.ftl
@@ -150,15 +150,15 @@ public class ${name}GuiWindow extends HandledScreen<${name}Gui.GuiContainerMod> 
 		<#list data.components as component>
 			<#if component.getClass().getSimpleName() == "TextField">
 				${component.name} = new TextFieldWidget(this.textRenderer, this.x + ${(component.x - mx/2)?int}, this.y + ${(component.y - my/2)?int},
-				${component.width}, ${component.height}, new StringTextComponent("${component.placeholder}"))
+				${component.width}, ${component.height}, new LiteralText("${component.placeholder}"))
 				<#if component.placeholder?has_content>
 				{
 					{
 						setSuggestion("${component.placeholder}");
 					}
 
-					@Override public void writeText(String text) {
-						super.writeText(text);
+					@Override public void write(String text) {
+						super.write(text);
 
 						if(getText().isEmpty())
 							setSuggestion("${component.placeholder}");
@@ -166,8 +166,8 @@ public class ${name}GuiWindow extends HandledScreen<${name}Gui.GuiContainerMod> 
 							setSuggestion(null);
 					}
 
-					@Override public void setCursorPosition(int pos) {
-						super.setCursorPosition(pos);
+					@Override public void setCursor(int pos) {
+						super.setCursor(pos);
 
 						if(getText().isEmpty())
 							setSuggestion("${component.placeholder}");
@@ -177,7 +177,7 @@ public class ${name}GuiWindow extends HandledScreen<${name}Gui.GuiContainerMod> 
 				}
 				</#if>;
                 guistate.put("text:${component.name}", ${component.name});
-				${component.name}.setMaxStringLength(32767);
+				${component.name}.setMaxLength(32767);
                 this.children.add(this.${component.name});
 			<#elseif component.getClass().getSimpleName() == "Button">
 				this.addButton(new ButtonWidget(this.x + ${(component.x - mx/2)?int}, this.y + ${(component.y - my/2)?int},

--- a/src/fabric-1.16.5/templates/gui_window.java.ftl
+++ b/src/fabric-1.16.5/templates/gui_window.java.ftl
@@ -28,7 +28,7 @@ package ${package}.client.gui.screen;
 public class ${name}GuiWindow extends HandledScreen<${name}Gui.GuiContainerMod> {
 
 	private World world;
-	private int x, y, z;
+	private int positionX, positionY, positionZ;
 	private PlayerEntity entity;
 
 	private final static HashMap guistate = ${name}Gui.guistate;
@@ -44,9 +44,9 @@ public class ${name}GuiWindow extends HandledScreen<${name}Gui.GuiContainerMod> 
 	public ${name}GuiWindow(${name}Gui.GuiContainerMod container, PlayerInventory inventory, Text text) {
 		super(container, inventory, text);
 		this.world = container.world;
-		this.x = container.x;
-		this.y = container.y;
-		this.z = container.z;
+		this.positionX = container.x;
+		this.positionY = container.y;
+		this.positionZ = container.z;
 		this.entity = container.entity;
 		this.backgroundWidth = ${data.width};
 		this.backgroundHeight = ${data.height};
@@ -183,7 +183,7 @@ public class ${name}GuiWindow extends HandledScreen<${name}Gui.GuiContainerMod> 
 				this.addButton(new ButtonWidget(this.x + ${(component.x - mx/2)?int}, this.y + ${(component.y - my/2)?int},
 					${component.width}, ${component.height}, new LiteralText("${component.text}"), e -> {
 						if (<@procedureOBJToConditionCode component.displayCondition/>) {
-			                ClientPlayNetworking.send(${JavaModName}.id("${name?lower_case}_button_${btid}"), new ${name}Gui.ButtonPressedMessage(${btid}, x, y, z));
+			                ClientPlayNetworking.send(${JavaModName}.id("${name?lower_case}_button_${btid}"), new ${name}Gui.ButtonPressedMessage(${btid}, positionX, positionY, positionZ));
 						}
 					}
 				)

--- a/src/fabric-1.16.5/templates/item.java.ftl
+++ b/src/fabric-1.16.5/templates/item.java.ftl
@@ -173,13 +173,14 @@ public class ${name}Item extends Item {
 
 <#if hasProcedure(data.onRightClickedInAir)>
     @Override
-    public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
-        ItemStack itemstack = super.use(world, user, hand).getResult();
+    public TypedActionResult<ItemStack> use(World world, PlayerEntity entity, Hand hand) {
+		TypedActionResult<ItemStack> retval = super.use(world, entity, hand);
+		ItemStack itemstack = retval.getValue();
         int x = (int) entity.getPos().getX();
         int y = (int) entity.getPos().getY();
         int z = (int) entity.getPos().getZ();
             <@procedureOBJToCode data.onRightClickedInAir/>
-        return super.use(world, user, hand);
+        return super.use(world, entity, hand);
     }
 </#if>
 }

--- a/src/fabric-1.16.5/templates/item.java.ftl
+++ b/src/fabric-1.16.5/templates/item.java.ftl
@@ -176,9 +176,9 @@ public class ${name}Item extends Item {
     public TypedActionResult<ItemStack> use(World world, PlayerEntity entity, Hand hand) {
 		TypedActionResult<ItemStack> retval = super.use(world, entity, hand);
 		ItemStack itemstack = retval.getValue();
-        int x = (int) entity.getPos().getX();
-        int y = (int) entity.getPos().getY();
-        int z = (int) entity.getPos().getZ();
+        double x = entity.getPos().getX();
+        double y = entity.getPos().getY();
+        double z = entity.getPos().getZ();
             <@procedureOBJToCode data.onRightClickedInAir/>
         return super.use(world, entity, hand);
     }

--- a/src/fabric-1.16.5/templates/modbase/client.java.ftl
+++ b/src/fabric-1.16.5/templates/modbase/client.java.ftl
@@ -79,6 +79,10 @@ public class ClientInit implements ClientModInitializer{
         </#list>
         });
 
+        <#list w.getElementsOfType("gui") as gui>
+            ScreenRegistry.register(${JavaModName}.${gui}ScreenType, ${gui}GuiWindow::new);
+        </#list>
+
         ClientTickEvents.END_CLIENT_TICK.register((client) -> {
             <#list w.getElementsOfType("keybind") as keybind>
             if(((${keybind}KeyBinding) ${keybind}_KEY).isPressed() && !((${keybind}KeyBinding) ${keybind}_KEY).wasPressed()){

--- a/src/fabric-1.16.5/templates/modbase/mod.java.ftl
+++ b/src/fabric-1.16.5/templates/modbase/mod.java.ftl
@@ -67,6 +67,9 @@ public class ${JavaModName} implements ModInitializer {
 	<#assign ge = block.getGeneratableElement()>
 	public static final Block ${block}_BLOCK = Registry.register(Registry.BLOCK, id("${block.getRegistryName()}"), new ${block}Block());
 	public static final BlockItem ${block}_ITEM = Registry.register(Registry.ITEM, id("${block.getRegistryName()}"), new BlockItem(${block}_BLOCK, new Item.Settings().group(${ge.creativeTab})));
+	<#if ge.hasInventory>
+	public static final BlockEntityType<${block}Block.CustomBlockEntity> ${block}_BLOCK_ENTITY = Registry.register(Registry.BLOCK_ENTITY_TYPE, id("${block.getRegistryName()}"), BlockEntityType.Builder.create(${block}Block.CustomBlockEntity::new, ${block}_BLOCK).build(null));
+	</#if>
 </#list>
 
 <#list w.getElementsOfType("plant") as plant>

--- a/src/fabric-1.16.5/templates/modbase/mod.java.ftl
+++ b/src/fabric-1.16.5/templates/modbase/mod.java.ftl
@@ -124,6 +124,10 @@ public class ${JavaModName} implements ModInitializer {
             id("${painting.getRegistryName()}"), ${painting}Painting.painting);
 </#list>
 
+<#list w.getElementsOfType("gui") as gui>
+	public static final ScreenHandlerType<${gui}Gui.GuiContainerMod> ${gui}ScreenType = ScreenHandlerRegistry.registerExtended(id("${gui.getRegistryName()}"), ${gui}Gui.GuiContainerMod::new);
+</#list>
+
 	@Override
 	public void onInitialize() {
 		LOGGER.info("Initializing ${JavaModName}");
@@ -162,6 +166,10 @@ public class ${JavaModName} implements ModInitializer {
 
 		<#list w.getElementsOfType("structure") as structure>
 			${structure}Structure.init();
+		</#list>
+
+		<#list w.getElementsOfType("gui") as gui>
+			${gui}GuiWindow.screenInit();
 		</#list>
 
 		<#list sounds as sound>


### PR DESCRIPTION
Add full support for the GUI mod element (except a trigger) and support for block, entity and item inventories. It also adds support for all GUI/Slot related procedure blocks. However, block/entity/item inventory procedure blocks are not added because they have been designed to use a Forge feature.
Closes #64