### PR TITLE
Fixed Fishing Rods Mixins (And mixins.json)

### DIFF
--- a/src/fabric-1.19.2/generator.yaml
+++ b/src/fabric-1.19.2/generator.yaml
@@ -66,6 +66,7 @@ base_templates:
   writer: file
   name: "@RESROOT/@modid.mixins.json"
   condition: ${w.hasToolsOfType("Fishing rod")}
+  deleteWhenConditionFalse: true
 
 sources_setup_tasks:
   - task: copy_models

--- a/src/fabric-1.19.2/generator.yaml
+++ b/src/fabric-1.19.2/generator.yaml
@@ -62,6 +62,10 @@ base_templates:
   canLock: true
   condition: ${settings.getMCreatorDependenciesRaw()?seq_contains("terrablender")}
   deleteWhenConditionFalse: true
+- template: modbase/mixins.json.ftl
+  writer: file
+  name: "@RESROOT/@modid.mixins.json"
+  condition: ${w.hasToolsOfType("Fishing rod")}
 
 sources_setup_tasks:
   - task: copy_models

--- a/src/fabric-1.19.2/templates/mixins/fishhookmixin.java.ftl
+++ b/src/fabric-1.19.2/templates/mixins/fishhookmixin.java.ftl
@@ -28,9 +28,8 @@ public abstract class ${JavaModName}FishingHookMixin extends EntityMixin {
 		ItemStack itemStack2 = player.getOffhandItem();
 		<#list tools as tool>
 			<#if tool.toolType == "Fishing rod">
-				if (player.isRemoved() || !player.isAlive() || !itemStack.is(${JavaModName}Items.${tool.getModElement().getRegistryNameUpper()}) && !itemStack2.is(${JavaModName}Items.${tool.getModElement().getRegistryNameUpper()}) || this.distanceToSqr(player) > 1024.0) {
-					this.discard();
-					cir.setReturnValue(true);
+				if (!player.isRemoved() && player.isAlive() && (itemStack.is(${JavaModName}Items.${tool.getModElement().getRegistryNameUpper()}) || itemStack2.is(${JavaModName}Items.${tool.getModElement().getRegistryNameUpper()})) && this.distanceToSqr(player) < 1024.0) {
+					cir.setReturnValue(false);
 				}
 			</#if>
 		</#list>

--- a/src/fabric-1.19.2/templates/mixins/fishhookrenderermixin.java.ftl
+++ b/src/fabric-1.19.2/templates/mixins/fishhookrenderermixin.java.ftl
@@ -1,0 +1,59 @@
+<#--
+ # This file is part of Fabric-Generator-MCreator.
+ # Copyright (C) 2020-2022, Goldorion, opensource contributors
+ #
+ # Fabric-Generator-MCreator is free software: you can redistribute it and/or modify
+ # it under the terms of the GNU Lesser General Public License as published by
+ # the Free Software Foundation, either version 3 of the License, or
+ # (at your option) any later version.
+
+ # Fabric-Generator-MCreator is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ # GNU Lesser General Public License for more details.
+ #
+ # You should have received a copy of the GNU Lesser General Public License
+ # along with Fabric-Generator-MCreator.  If not, see <https://www.gnu.org/licenses/>.
+-->
+package ${package}.mixins;
+
+import ${package}.mixins.EntityMixin;
+import org.spongepowered.asm.mixin.injection.Constant;
+
+@Mixin(FishingHookRenderer.class)
+public abstract class ${JavaModName}FishingHookRendererMixin {
+	double offset = 0.35;
+	float offset2 = 0.525f;
+
+	@Inject(method = "render", at = @At("HEAD"))
+	public void render(FishingHook fishingHook, float f, float g, PoseStack poseStack, MultiBufferSource multiBufferSource, int i, CallbackInfo ci) {
+		Player playerino = fishingHook.getPlayerOwner();
+		ItemStack itemStack = playerino.getMainHandItem();
+		ItemStack itemStack2 = playerino.getOffhandItem();
+		<#list tools as tool>
+			<#if tool.toolType == "Fishing rod">
+				if (itemStack.is(${JavaModName}Items.${tool.getModElement().getRegistryNameUpper()})) {
+					offset = -0.35;
+					offset2 = -0.525f;
+				} else if (itemStack.is(Items.FISHING_ROD)) {
+					offset = 0.35;
+					offset2 = 0.525f;
+				} else if (itemStack2.is(${JavaModName}Items.${tool.getModElement().getRegistryNameUpper()})) {
+					offset = 0.35;
+					offset2 = 0.525f;
+				}
+			</#if>
+		</#list>
+	}
+
+	@ModifyConstant(method = "render", constant = @Constant(doubleValue = 0.35))
+	private double injected(double x) {
+		return offset;
+	}
+
+	@ModifyConstant(method = "render", constant = @Constant(floatValue = 0.525f))
+	private float injected(float x) {
+		return offset2;
+	}
+}
+<#-- @formatter:on -->

--- a/src/fabric-1.19.2/templates/modbase/mixins.json.ftl
+++ b/src/fabric-1.19.2/templates/modbase/mixins.json.ftl
@@ -5,7 +5,8 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
 	"EntityMixin",
-	"${settings.getJavaModName()}FishingHookMixin"
+	"${settings.getJavaModName()}FishingHookMixin",
+	"${settings.getJavaModName()}FishingHookRendererMixin"
   ],
   "injectors": {
 	"defaultRequire": 1

--- a/src/fabric-1.19.2/tool.definition.yaml
+++ b/src/fabric-1.19.2/tool.definition.yaml
@@ -22,6 +22,11 @@ global_templates:
     condition: ${w.hasToolsOfType("Fishing rod")}
     deleteWhenConditionFalse: true
     name: "@SRCROOT/@BASEPACKAGEPATH/mixins/@JavaModNameFishingHookMixin.java"
+  - template: mixins/fishhookrenderermixin.java.ftl
+    writer: java
+    condition: ${w.hasToolsOfType("Fishing rod")}
+    deleteWhenConditionFalse: true
+    name: "@SRCROOT/@BASEPACKAGEPATH/mixins/@JavaModNameFishingHookRendererMixin.java"
   - template: mixins/entitymixin.java.ftl
     writer: java
     condition: ${w.hasToolsOfType("Fishing rod")}


### PR DESCRIPTION
Added a new mixin to fix the line render.
Fixed the previous mixin to not make it instantly delete the bobber.
Added mixin.jsons to generator.yaml, allowing it to generate when it's needed (Previously didn't generate)