### PR TITLE
Removed "Armor" from "Partially Supported"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ This project is not official. It is not affiliated with the respective owners an
 Mod elements that are not mentioned are completely supported with all available features with Fabric.
 
 ### Partially supported (almost completed)
-* Armor
 * Biome
 * Living entity
   


### PR DESCRIPTION
Since armor tick events are now supported, Armor is now fully supported. (I think.)