### PR TITLE
URGENT FIX Update build.gradle

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # Changelogs:
 
+## 1.7.1
+* [Bugfix #313] Mods could not be exported (once again)
+
 ## 1.7
 ## Release
 * [#292] Added Projectile related procedures (kleiders)

--- a/src/fabric-1.19.2/generator.yaml
+++ b/src/fabric-1.19.2/generator.yaml
@@ -1,7 +1,7 @@
 name: Minecraft Fabric for @minecraft - @buildfileversion
 status: stable
 buildfileversion: 0.60.0
-subversion: 1.9
+subversion: 10
 
 java_models:
   key: mojmap-1.19.x

--- a/src/fabric-1.19.2/workspacebase/build.gradle
+++ b/src/fabric-1.19.2/workspacebase/build.gradle
@@ -6,7 +6,7 @@ sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 
 archivesBaseName = 'modid'
-version = '1.0'
+version = '1.0.0'
 group = 'com.yourname.modid'
 actualmodid = '${modid}'
 

--- a/src/fabric-1.19.2/workspacebase/build.gradle
+++ b/src/fabric-1.19.2/workspacebase/build.gradle
@@ -5,9 +5,9 @@ plugins {
 sourceCompatibility = JavaVersion.VERSION_17
 targetCompatibility = JavaVersion.VERSION_17
 
-archivesBaseName = '${modid}'
-version = '1.0.0'
-group = '${package}'
+archivesBaseName = 'modid'
+version = '1.0'
+group = 'com.yourname.modid'
 actualmodid = '${modid}'
 
 dependencies {


### PR DESCRIPTION
Vital Fix for build.gradle, otherwise mods can't be exported. This requires a re-release of the latest fabric generator version!