### PR TITLE
Updated Player Join world event to provide the proper dependencies

### DIFF
--- a/src/fabric-1.19.2/triggers/player_log_in.java.ftl
+++ b/src/fabric-1.19.2/triggers/player_log_in.java.ftl
@@ -1,11 +1,11 @@
 public ${name}Procedure() {
 	ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> {
 		Map<String, Object> dependencies = new HashMap<>();
-		dependencies.put("entity", Minecraft.getInstance().player);
-		dependencies.put("x", Minecraft.getInstance().player.getX());
-		dependencies.put("y", Minecraft.getInstance().player.getY());
-		dependencies.put("z", Minecraft.getInstance().player.getZ());
-		dependencies.put("world", Minecraft.getInstance().player.level);
+		dependencies.put("entity", handler.getPlayer());
+		dependencies.put("x", handler.getPlayer().getX());
+		dependencies.put("y", handler.getPlayer().getY());
+		dependencies.put("z", handler.getPlayer().getZ());
+		dependencies.put("world", handler.getPlayer().getLevel());
 		execute(dependencies);
 	});
 }

--- a/src/fabric-1.19.2/triggers/player_log_out.java.ftl
+++ b/src/fabric-1.19.2/triggers/player_log_out.java.ftl
@@ -1,11 +1,11 @@
 public ${name}Procedure() {
 	ServerPlayConnectionEvents.DISCONNECT.register((handler, server) -> {
 		Map<String, Object> dependencies = new HashMap<>();
-		dependencies.put("entity", Minecraft.getInstance().player);
-		dependencies.put("x", Minecraft.getInstance().player.getX());
-		dependencies.put("y", Minecraft.getInstance().player.getY());
-		dependencies.put("z", Minecraft.getInstance().player.getZ());
-		dependencies.put("world", Minecraft.getInstance().player.level);
+		dependencies.put("entity", handler.getPlayer());
+		dependencies.put("x", handler.getPlayer().getX());
+		dependencies.put("y", handler.getPlayer().getY());
+		dependencies.put("z", handler.getPlayer().getZ());
+		dependencies.put("world", handler.getPlayer().getLevel());
 		execute(dependencies);
 	});
 }


### PR DESCRIPTION
Old one provided everything from getInstance(), which is not at all ideal. Instead, it nows get all dependencies from handler.