### PR TITLE
A very very little change in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -2,6 +2,16 @@ name: Bug report
 description: Create a report to help us improve (search for duplicates first)
 labels: bug
 body:
+  - type: checkboxes
+    attributes:
+      label: Issue tracker rule checks (please read carefully)
+      options:
+        - label: "I have checked that my problem <a href='https://github.com/MCreator/MCreator/issues?q=is%3Aissue' target='_blank'>is not already reported</a>"
+          required: true
+        - label: "I have checked that my problem is not covered on <a href='https://mcreator.net/support/knowledgebase' target='_blank'>Knowledge Base</a> or on <a href='https://mcreator.net/wiki' target='_blank'>MCreator's Wiki</a>"
+          required: true
+        - label: "I have checked that my written content does not violate the <a href='https://mcreator.net/wiki/general-publishing-guidelines' target='_blank'>publishing guidelines</a>"
+          required: true
   - type: textarea
     attributes:
       label: Issue description
@@ -61,13 +71,4 @@ body:
       placeholder: https://gist.github.com/...
     validations:
       required: false
-  - type: checkboxes
-    attributes:
-      label: Issue tracker rule checks (please read carefully)
-      options:
-        - label: "I have checked that my problem <a href='https://github.com/MCreator/MCreator/issues?q=is%3Aissue' target='_blank'>is not already reported</a>"
-          required: true
-        - label: "I have checked that my problem is not covered on <a href='https://mcreator.net/support/knowledgebase' target='_blank'>Knowledge Base</a> or on <a href='https://mcreator.net/wiki' target='_blank'>MCreator's Wiki</a>"
-          required: true
-        - label: "I have checked that my written content does not violate the <a href='https://mcreator.net/wiki/general-publishing-guidelines' target='_blank'>publishing guidelines</a>"
-          required: true
+      

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -2,14 +2,6 @@ name: Feature Request
 description: Suggest an idea for the plugin
 labels: feature request
 body:
- - type: textarea
-   attributes:
-    label: Feature description
-    description: Explain in details the request
-    placeholder: |
-     Tell us here about the feature
-   validations:
-    required: true
  - type: checkboxes
    attributes:
     label: Issue tracker rule checks (please read carefully)
@@ -18,3 +10,11 @@ body:
        required: true
      - label: "I have checked that my written content does not violate the <a href='https://mcreator.net/wiki/general-publishing-guidelines' target='_blank'>publishing guidelines</a>"
        required: true
+ - type: textarea
+   attributes:
+    label: Feature description
+    description: Explain in details the request
+    placeholder: |
+     Tell us here about the feature
+   validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,7 +4,7 @@ labels: feature request
 body:
  - type: checkboxes
    attributes:
-    label: Issue tracker rule checks (please read carefully)
+    label: Prerequisites
     options:
      - label: "I have checked that this feature [is not already asked](https://github.com/Goldorion/Fabric-Generator-MCreator/issues)."
        required: true


### PR DESCRIPTION
Did this because I've seen that many new reporters don't even read these and click on Checkbox. And Devs have to manually see which one's the duplicate...

By doing this, there is 50% chance that they'll skip reading it but there is also 50% chance that because its on top, they might have a peek on it... and if they have there is another 50% chance that they'll report 'cuz its new issue and 50% chance that they won't report..

(Sorry, I am Asian, kind of data presenter and okayish in maths... sorry if you cant understand it lol cuz im not good in eng)
Overall, it 'may' reduce the amount of work by 50% of Goldorion. (MAYBE..)